### PR TITLE
Ensure all packs are freshly reloaded on init

### DIFF
--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -101,6 +101,7 @@ EXPOSE 22 443
 VOLUME ["/opt/stackstorm/packs.dev"]
 
 COPY bin/entrypoint.sh /entrypoint.sh
+COPY conf/local.conf /etc/init/local.conf
 
 # Default username/password is used unless overridden by supplying ST2_USER and/or ST2_PASSWORD
 # environment variables to `docker run` after the name of the image:

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -19,7 +19,4 @@ crudini --set /root/.st2/config credentials password ${ST2_PASSWORD}
 #
 #  $ st2 run packs.setup_virtualenv packs=examples
 
-st2ctl reload --register-all
-
 exec /sbin/init
-

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -19,4 +19,7 @@ crudini --set /root/.st2/config credentials password ${ST2_PASSWORD}
 #
 #  $ st2 run packs.setup_virtualenv packs=examples
 
+st2ctl reload --register-all
+
 exec /sbin/init
+

--- a/images/stackstorm/conf/local.conf
+++ b/images/stackstorm/conf/local.conf
@@ -1,0 +1,15 @@
+description "Local startup"
+author "StackStorm"
+
+start on started st2api
+stop on shutdown
+
+script
+
+logger Starting local init...
+
+st2ctl reload --register-all
+
+logger Ending local init
+
+end script


### PR DESCRIPTION
Just adding an `st2ctl reload --register-all` to the entrypoint so the user doesn't have to do this.