### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ Within the container, run the following:
 
   ```
   echo "    - /tmp/date.log" >> /opt/stackstorm/packs/linux/config.yaml
-  st2 sensor enable linux.FileWatchSensor
   st2ctl reload
+  st2 sensor enable linux.FileWatchSensor
   ```
 
 When we append to `/tmp/date.log`, the sensor will inject a trigger that matches the criteria.


### PR DESCRIPTION
Given that the FileWatchSensor is disabled by default
(check the content of /opt/stackstorm/packs/linux/sensors/file_watch_sensor.yaml
file in the container), doing a st2ctl reload after enabling this sensor
will disable it. So, we have to enable the sensor after the reload.