### PR TITLE
Auto-generate env vars with default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 packs
 packs.dev
 *.pyc
+conf

--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,11 @@ rmi:
 
 exec:
 	docker exec -it stackstorm /bin/bash
+
+clean:
+	docker system prune -f
+
+clean-all: clean
+	docker volume rm -f st2docker_mongo-volume st2docker_postgres-volume \
+		st2docker_rabbitmq-volume st2docker_redis-volume
+	rm -rf conf

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 build:
 	docker build -t stackstorm/stackstorm:latest images/stackstorm
 
+env:
+	bin/write-env.sh conf
+
 up:
 	docker-compose up -d
 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,25 @@ The initial container configuration is as follows:
 We use Version 3 of the compose file format, so if you want to run docker-compose, you'll need to
 ensure you're running Docker Engine release 1.13.0+.
 
-Start the docker environment (specifying a custom ST2 user and password if the defaults are not desired):
+First, execute
 
   ```
-  [ST2_USER=<user>] [ST2_PASSWORD=<password>] docker-compose up -d
+  make env
   ```
 
-`docker-compose up -d` will pull the required images from docker hub, and then start them.
+to create the environment files used by docker-compose. You may want to change the values of the
+variables as necessary, but the defaults should be okay if you are not using any off-cluster
+services (e.g. mongo, redis, postgres, rabbitmq).
 
-If you modify the stackstorm image, you will need to build it. Run:
+Second, start the docker environment.
+
+  ```
+  docker-compose up -d
+  ```
+
+This will pull the required images from docker hub, and then start them.
+
+However, if you find need to modify the stackstorm image, you will need to build it. Run:
 
   ```
   REPO=stable

--- a/bin/write-env.sh
+++ b/bin/write-env.sh
@@ -18,16 +18,19 @@ if [ ! -f ${CONF_DIR}/postgres.env ]; then
   echo "POSTGRES_USER=${POSTGRES_USER:-mistral-user}" > ${CONF_DIR}/postgres.env
   echo "POSTGRES_PASSWORD=${POSTGRES_PASS:-$(randpwd 18)}" >> ${CONF_DIR}/postgres.env
   echo "POSTGRES_HOST=${POSTGRES_HOST:-postgres}" >> ${CONF_DIR}/postgres.env
+  echo "POSTGRES_PORT=${POSTGRES_PORT:-5432}" >> ${CONF_DIR}/postgres.env
   echo "POSTGRES_DB=${POSTGRES_DB:-mistral}" >> ${CONF_DIR}/postgres.env
 fi
 if [ ! -f ${CONF_DIR}/rabbitmq.env ]; then
   echo "RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER:-admin}" > ${CONF_DIR}/rabbitmq.env
   echo "RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS:-$(randpwd 18)}" >> ${CONF_DIR}/rabbitmq.env
   echo "RABBITMQ_HOST=${RABBITMQ_HOST:-rabbitmq}" >> ${CONF_DIR}/rabbitmq.env
+  echo "RABBITMQ_PORT=${RABBITMQ_PORT:-5672}" >> ${CONF_DIR}/rabbitmq.env
 fi
 if [ ! -f ${CONF_DIR}/redis.env ]; then
   echo "REDIS_PASSWORD=${REDIS_PASSWORD:-$(randpwd 18)}" > ${CONF_DIR}/redis.env
   echo "REDIS_HOST=${REDIS_HOST:-redis}" >> ${CONF_DIR}/redis.env
+  echo "REDIS_PORT=${REDIS_PORT:-6379}" >> ${CONF_DIR}/redis.env
 fi
 if [ ! -f ${CONF_DIR}/stackstorm.env ]; then
   echo "ST2_USER=${ST2_USER:-st2admin}" > ${CONF_DIR}/stackstorm.env

--- a/bin/write-env.sh
+++ b/bin/write-env.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Create env files in the specified directory
+
+CONF_DIR=${1:-conf}
+
+function randpwd()
+{
+  echo $(openssl rand -base64 $1 | tr '/' 'A')
+}
+
+mkdir -p ${CONF_DIR}
+
+if [ ! -f ${CONF_DIR}/mongo.env ]; then
+  touch ${CONF_DIR}/mongo.env
+fi
+if [ ! -f ${CONF_DIR}/postgres.env ]; then
+  echo "POSTGRES_USER=${POSTGRES_USER:-mistral-user}" > ${CONF_DIR}/postgres.env
+  echo "POSTGRES_PASSWORD=${POSTGRES_PASS:-$(randpwd 18)}" >> ${CONF_DIR}/postgres.env
+  echo "POSTGRES_HOST=${POSTGRES_HOST:-postgres}" >> ${CONF_DIR}/postgres.env
+  echo "POSTGRES_DB=${POSTGRES_DB:-mistral}" >> ${CONF_DIR}/postgres.env
+fi
+if [ ! -f ${CONF_DIR}/rabbitmq.env ]; then
+  echo "RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER:-admin}" > ${CONF_DIR}/rabbitmq.env
+  echo "RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS:-$(randpwd 18)}" >> ${CONF_DIR}/rabbitmq.env
+  echo "RABBITMQ_HOST=${RABBITMQ_HOST:-rabbitmq}" >> ${CONF_DIR}/rabbitmq.env
+fi
+if [ ! -f ${CONF_DIR}/redis.env ]; then
+  echo "REDIS_PASSWORD=${REDIS_PASSWORD:-$(randpwd 18)}" > ${CONF_DIR}/redis.env
+  echo "REDIS_HOST=${REDIS_HOST:-redis}" >> ${CONF_DIR}/redis.env
+fi
+if [ ! -f ${CONF_DIR}/stackstorm.env ]; then
+  echo "ST2_USER=${ST2_USER:-st2admin}" > ${CONF_DIR}/stackstorm.env
+  echo "ST2_PASSWORD=${ST2_PASSWORD:-$(randpwd 6)}" >> ${CONF_DIR}/stackstorm.env
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - conf/mongo.env
       - conf/rabbitmq.env
       - conf/postgres.env
+      - conf/redis.env
     ports:
       - "443:443"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       - conf/mongo.env
     networks:
       - private
+    volumes:
+      - mongo-volume:/data/db
   rabbitmq:
     image: rabbitmq:management
     container_name: rabbitmq
@@ -38,6 +40,8 @@ services:
       - conf/rabbitmq.env
     networks:
       - private
+    volumes:
+      - rabbitmq-volume:/var/lib/rabbitmq
   postgres:
     image: postgres:latest
     container_name: postgres
@@ -45,6 +49,8 @@ services:
       - conf/postgres.env
     networks:
       - private
+    volumes:
+      - postgres-volume:/var/lib/postgresql/data
   redis:
     image: redis:latest
     container_name: redis
@@ -52,9 +58,14 @@ services:
       - conf/redis.env
     networks:
       - private
+    volumes:
+      - redis-volume:/data
 
 volumes:
-  data:
+  mongo-volume:
+  postgres-volume:
+  rabbitmq-volume:
+  redis-volume:
 
 networks:
   public:

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -17,9 +17,9 @@ ST2_CONF=/etc/st2/st2.conf
 crudini --set ${ST2_CONF} mistral api_url http://127.0.0.1:9101
 crudini --set ${ST2_CONF} mistral v2_base_url http://127.0.0.1:8989/v2
 crudini --set ${ST2_CONF} messaging url \
-  amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:5672
+  amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}
 crudini --set ${ST2_CONF} coordination url \
-  redis://${REDIS_PASSWORD}@${REDIS_HOST}:6379
+  redis://${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}
 
 # NOTE: Only certain distros of MongoDB support SSL/TLS
 #  1) enterprise versions
@@ -35,8 +35,8 @@ crudini --set ${ST2_CONF} coordination url \
 MISTRAL_CONF=/etc/mistral/mistral.conf
 
 crudini --set ${MISTRAL_CONF} DEFAULT transport_url \
-  rabbit://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:5672
+  rabbit://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}
 crudini --set ${MISTRAL_CONF} database connection \
-  postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/${POSTGRES_DB}
+  postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 exec /sbin/init

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -18,8 +18,6 @@ crudini --set ${ST2_CONF} mistral api_url http://127.0.0.1:9101
 crudini --set ${ST2_CONF} mistral v2_base_url http://127.0.0.1:8989/v2
 crudini --set ${ST2_CONF} messaging url \
   amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}
-crudini --set ${ST2_CONF} coordination url \
-  redis://${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}
 
 # NOTE: Only certain distros of MongoDB support SSL/TLS
 #  1) enterprise versions

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-ST2_USER=${ST2_USER:-st2admin}
-ST2_PASSWORD=${ST2_PASSWORD:-Ch@ngeMe}
-RMQ_USER=${RABBITMQ_DEFAULT_USER:-admin}
-RMQ_PASS=${RABBITMQ_DEFAULT_PASS:-pwd123}
-
 # Create htpasswd file and login to st2 using specified username/password
 htpasswd -b /etc/st2/htpasswd ${ST2_USER} ${ST2_PASSWORD}
 
@@ -21,7 +16,10 @@ ST2_CONF=/etc/st2/st2.conf
 
 crudini --set ${ST2_CONF} mistral api_url http://127.0.0.1:9101
 crudini --set ${ST2_CONF} mistral v2_base_url http://127.0.0.1:8989/v2
-crudini --set ${ST2_CONF} messaging url amqp://${RMQ_USER}:${RMQ_PASS}@rabbitmq:5672
+crudini --set ${ST2_CONF} messaging url \
+  amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:5672
+crudini --set ${ST2_CONF} coordination url \
+  redis://${REDIS_PASSWORD}@${REDIS_HOST}:6379
 
 # NOTE: Only certain distros of MongoDB support SSL/TLS
 #  1) enterprise versions
@@ -36,7 +34,9 @@ crudini --set ${ST2_CONF} messaging url amqp://${RMQ_USER}:${RMQ_PASS}@rabbitmq:
 
 MISTRAL_CONF=/etc/mistral/mistral.conf
 
-crudini --set ${MISTRAL_CONF} DEFAULT transport_url rabbit://${RMQ_USER}:${RMQ_PASS}@rabbitmq:5672
-crudini --set ${MISTRAL_CONF} database connection postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${POSTGRES_DB}
+crudini --set ${MISTRAL_CONF} DEFAULT transport_url \
+  rabbit://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:5672
+crudini --set ${MISTRAL_CONF} database connection \
+  postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/${POSTGRES_DB}
 
 exec /sbin/init


### PR DESCRIPTION
Prior to this commit, the env files were not committed to the repo and passwords were hardcoded. Now, we use randomly generated passwords and document the procedure used to create the files.

Further, it should now be possible to configure the `stackstorm` container to use off-cluster services using these env variables.

This PR resolves https://github.com/StackStorm/st2-docker/issues/3.