### PR TITLE
Add persistent storage for stackstorm:/var/log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ env:
 up:
 	docker-compose up -d
 
+down:
+	docker-compose down
+
 rmi:
 	docker rmi $$(docker images -f dangling=true -q)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ The default container configuration is as follows:
  - postgres
  - redis
 
-The mongo, rabbitmq, postgres and redis containers use persistent storage.
+The mongo, rabbitmq, postgres and redis containers store their data
+on persistent storage. Additionally, the stackstorm container persists
+the contents of `/var/log`. If you do not wish to persist this data,
+then remove the appropriate entries from `docker-compose.yml`.
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - public
       - private
     volumes:
+      - stackstorm-log-volume:/var/log
       - ./packs.dev:/opt/stackstorm/packs.dev
 
 ### External Services
@@ -66,6 +67,7 @@ volumes:
   postgres-volume:
   rabbitmq-volume:
   redis-volume:
+  stackstorm-log-volume:
 
 networks:
   public:

--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -96,7 +96,7 @@ RUN wget -O - http://nginx.org/keys/nginx_signing.key | apt-key add - \
 
 EXPOSE 22 443
 
-# Make /opt/stackstorm/packs.dev available on the host in the ./packs.dev directory.
+# Share /opt/stackstorm/packs.dev with the host
 # NOTE: This is intended to be used for pack development.
 VOLUME ["/opt/stackstorm/packs.dev"]
 


### PR DESCRIPTION
The `stackstorm` container now stores /var/log on a docker volume. README is updated.

The new "down" target is coming along for the ride.