### PR TITLE
Add note on enabling/disabling chatops

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ You can also bind mount a specific directory to `/entrypoint.d` then place scrip
 
 Note: scripts will be executed in alphabetical order of the file name.
 
-## To enable chatops
+## To enable/disable chatops
+
+Chatops is installed in the `stackstorm` image, but not started by default.
 
 To enable chatops, delete the file `/etc/init/st2chatops.override` using a script in
 `/entrypoint.d`.

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ This container supports running arbitrary shell scripts on container boot. Any `
 
 For example, if you want to modify `/etc/st2/st2.conf` to set `system_packs_base_path` parameter, create `modify-st2-config.sh` with the follwing content:
 
-```
-/bin/bash
-crudini --set /etc/st2/st2.conf content system_packs_base_path /opt/stackstorm/custom_packs
-```
+  ```
+  #/bin/bash
+  crudini --set /etc/st2/st2.conf content system_packs_base_path /opt/stackstorm/custom_packs
+  ```
 
 Then bind mount it to `/entrypoint.d/modify-st2-config.sh`
 
@@ -116,6 +116,25 @@ The above example shows just modifying st2 config but basically there is no limi
 You can also bind mount a specific directory to `/entrypoint.d` then place scripts as much as you want. All of them will be executed as long as the file name ends with `*.sh`.
 
 Note: scripts will be executed in alphabetical order of the file name.
+
+## To enable chatops
+
+To enable chatops, delete the file `/etc/init/st2chatops.override` using a script in
+`/entrypoint.d`.
+
+  ```
+  #!/bin/bash
+
+  sudo rm /etc/init/st2chatops.override
+  ```
+
+If you need to disable chatops, run the following using a script in `/entrypoint.d`:
+
+  ```
+  #!/bin/bash
+
+  echo manual | sudo tee /etc/init/st2chatops.override
+  ```
 
 ## Adding a simple action
 


### PR DESCRIPTION
Current default is to install chatops, but disable it from starting. This allows us to suport one image instead of two (at the cost of a slightly larger image).

See #35 for more information.