### PR TITLE
Remove SYS_ADMIN/seccomp:unconfined

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,6 @@ version: '3'
 services:
   stackstorm:
     image: stackstorm/stackstorm:${TAG:-latest}
-    cap_add:
-      - SYS_ADMIN
-    security_opt:
-      - seccomp:unconfined
     container_name: stackstorm
     env_file:
       - conf/stackstorm.env


### PR DESCRIPTION
I did some basic testing, and couldn't find a reason why the default `docker-compose.yml` requires this capability. IIRC, there was a reason why I originally added it, but can't remember the details anymore.

Fixes #49 