### PR TITLE
Fix docker build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ However, if you find need to modify the stackstorm image, you will need to build
 
   ```
   REPO=stable
-  docker build --build-arg ST2_REPO=${REPO} stackstorm/stackstorm:${REPO}
+  docker build --build-arg ST2_REPO=${REPO} -t stackstorm/stackstorm:${REPO} images/stackstorm
   ```
 
 where REPO is one of 'stable', 'unstable', 'staging-stable', 'staging-unstable'.  Otherwise,


### PR DESCRIPTION
The `docker build` command was missing the location of `Dockerfile`, and did not identify `stackstorm/stackstorm:${REPO}` as the tag. These issues have been resolved.