### PR TITLE
Use Node.js v6 instead of v4

### DIFF
--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -85,8 +85,8 @@ RUN sed -i 's/start on filesystem and net-device-up IFACE!=lo/start on runlevel 
   /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf populate\n' /etc/init/mistral.conf
 
 # Install chatops and disable unless entrypoint.d file is present
-# Install st2-chatops with Node.js v4 requirement
-RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override
+# Install st2-chatops with Node.js v6 requirement
+RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override
 
 # Setup symmetric crypto key for datastore
 RUN mkdir -p /etc/st2/keys \


### PR DESCRIPTION
Use Node.js v6. This means we now need to run `setup_6.x` instead of `setup_4.x`.