### PR TITLE
Add tags only filter to build job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,11 @@ workflows:
   version: 2
   build_deploy:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only:
+                - /.*/
       - deploy:
           requires:
             - build


### PR DESCRIPTION
Applying a tag on a0b26a3 did not result in a build or deploy job being run.

This PR is untested. I'm testing it in production.