### PR TITLE
Use Travis CI for nightly "dev" build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+dist: trusty
+sudo: required
+
+branches:
+  only:
+    - master
+    - wvw/add-travis
+
+services:
+  - docker
+
+before_install:
+  - docker build --build-arg ST2_REPO=unstable --build-arg CIRCLE_SHA1=${TRAVIS_COMMIT} --build-arg CIRCLE_PROJECT_USERNAME=stackstorm --build-arg CIRCLE_PROJECT_REPONAME=st2-docker -t stackstorm/stackstorm:dev images/stackstorm
+  - docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
+  - docker push stackstorm/stackstorm:dev
+
+notifications:
+  email:
+    recipients:
+      - warren.van.winckel@gmail.com
+    on_success: never
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ before_install:
 
 install: true
 
+script: true
+
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: python
 branches:
   only:
     - master
-    - wvw/add-travis
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
   - docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
   - docker push stackstorm/stackstorm:dev
 
+install: true
+
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: trusty
 sudo: required
 
+language: python
+
 branches:
   only:
     - master


### PR DESCRIPTION
We do this because CircleCI does not currently allow us to trigger builds via cron, or trigger workflows using an API.