### PR TITLE
Add drivername to mistral database connection string

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ to create the environment files used by docker-compose. You may want to change t
 variables as necessary, but the defaults should be okay if you are not using any off-cluster
 services (e.g. mongo, redis, postgres, rabbitmq).
 
+NOTE: `make env` only needs to be run once.
+
 As an example, if you want to change the username and password used by StackStorm, change the
 `ST2_USER` and `ST2_PASSWORD` variables in `conf/stackstorm.env` prior to bringing up your docker
 environment.

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -48,7 +48,7 @@ MISTRAL_CONF=/etc/mistral/mistral.conf
 crudini --set ${MISTRAL_CONF} DEFAULT transport_url \
   rabbit://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}
 crudini --set ${MISTRAL_CONF} database connection \
-  postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+  postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # Run custom init scripts
 for f in /entrypoint.d/*; do


### PR DESCRIPTION
Use dbname+drivername as described in https://github.com/StackStorm/st2-packages/issues/490.

Also, add a note that `make env` need only be run once.
