### PR TITLE
Update README with a warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ then remove the appropriate entries from `docker-compose.yml`.
 
 ## READ FIRST!!
 
-- **Check the (CHANGELOG.rst)[https://github.com/StackStorm/st2-docker/blob/master/CHANGELOG.rst]** file for any potential changes that may require restarting containers.
+- **Check the [CHANGELOG.rst](https://github.com/StackStorm/st2-docker/blob/master/CHANGELOG.rst)** file for any potential
+  changes that may require restarting containers.
 - Be sure to use the latest `docker-compose.yml`. Run `git pull` in your `st2-docker` workspace!
 - Run `st2ctl reload --register-all` to reload all services.
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ on persistent storage. Additionally, the stackstorm container persists
 the contents of `/var/log`. If you do not wish to persist this data,
 then remove the appropriate entries from `docker-compose.yml`.
 
-## Before asking for help
+## READ FIRST!!
 
-If you ever notice `st2` errors (e.g. `No matching items found`) when running a new
-`stackstorm/stackstorm` container, be sure to run `git pull` in your `st2-docker` workspace before
-asking for help. Check the `CHANGELOG.rst` file for any potential changes that may require
-restarting containers. This may just solve your issue.
+- **Check the CHANGELOG.rst** file for any potential changes that may require restarting containers.
+- Be sure to use the latest `docker-compose.yml`. Run `git pull` in your `st2-docker` workspace!
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ then remove the appropriate entries from `docker-compose.yml`.
 
 ## READ FIRST!!
 
-- **Check the CHANGELOG.rst** file for any potential changes that may require restarting containers.
+- **Check the (CHANGELOG.rst)[https://github.com/StackStorm/st2-docker/blob/master/CHANGELOG.rst]** file for any potential changes that may require restarting containers.
 - Be sure to use the latest `docker-compose.yml`. Run `git pull` in your `st2-docker` workspace!
 - Run `st2ctl reload --register-all` to reload all services.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ on persistent storage. Additionally, the stackstorm container persists
 the contents of `/var/log`. If you do not wish to persist this data,
 then remove the appropriate entries from `docker-compose.yml`.
 
+## Warning
+
+If you pulled `st2-docker` prior to October 23, 2017 (`e99d209`), you will need to execute
+`git pull` in your workspace to pick up the latest changes. In particular, `docker-compose.yml` and
+`runtime/st2.d` scripts such as `reload.sh`.
+
 ## Usage
 
 We use Version 3 of the compose file format, so if you want to run docker-compose, you'll need to

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ on persistent storage. Additionally, the stackstorm container persists
 the contents of `/var/log`. If you do not wish to persist this data,
 then remove the appropriate entries from `docker-compose.yml`.
 
-## Warning
+## Note
 
-If you pulled `st2-docker` prior to October 23, 2017 (`e99d209`), you will need to execute
-`git pull` in your workspace to pick up the latest changes. In particular, `docker-compose.yml` and
-`runtime/st2.d` scripts such as `reload.sh`.
+If you ever notice `st2` errors (e.g. `No matching items found`) when running a new
+`stackstorm/stackstorm` container, be sure to run `git pull` in your `st2-docker` workspace before
+asking for help. Check the `CHANGELOG.rst` file for any potential changes that may require
+restarting containers. This may just solve your issue.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ on persistent storage. Additionally, the stackstorm container persists
 the contents of `/var/log`. If you do not wish to persist this data,
 then remove the appropriate entries from `docker-compose.yml`.
 
-## Note
+## Before asking for help
 
 If you ever notice `st2` errors (e.g. `No matching items found`) when running a new
 `stackstorm/stackstorm` container, be sure to run `git pull` in your `st2-docker` workspace before

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ then remove the appropriate entries from `docker-compose.yml`.
 
 - **Check the CHANGELOG.rst** file for any potential changes that may require restarting containers.
 - Be sure to use the latest `docker-compose.yml`. Run `git pull` in your `st2-docker` workspace!
+- Run `st2ctl reload --register-all` to reload all services.
 
 ## Usage
 


### PR DESCRIPTION
You must use the latest `docker-compose.yml` file from commit `e99d209` when running the `stackstorm/stackstorm:2.5.0` image. Otherwise you will see the following error:

```
ERROR: 400 Client Error: Bad Request
MESSAGE: Action "packs.install" cannot be found. for url: http://127.0.0.1:9101/v1/packs/install
```