### PR TITLE
Fix compose-1ppc

### DIFF
--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -94,8 +94,7 @@ RUN mkdir -p /etc/st2/keys \
     && usermod -a -G st2 st2 && chgrp st2 /etc/st2/keys && chmod o-r /etc/st2/keys \
     && chgrp st2 /etc/st2/keys/datastore_key.json && chmod o-r /etc/st2/keys/datastore_key.json \
     && crudini --set /etc/st2/st2.conf keyvalue encryption_key_path /etc/st2/keys/datastore_key.json \
-    && crudini --set /etc/st2/st2.conf auth enable True \
-    && crudini --set /etc/st2/st2.conf content packs_base_paths /opt/stackstorm/packs.dev
+    && crudini --set /etc/st2/st2.conf auth enable True
 
 # Install redis client library for coordination backend
 # see: https://docs.stackstorm.com/latest/reference/policies.html

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -14,8 +14,8 @@ crudini --set ${ROOT_CONF} credentials password ${ST2_PASSWORD}
 
 ST2_CONF=/etc/st2/st2.conf
 
-ST2_API_URL=http://127.0.0.1:9101
-MISTRAL_BASE_URL=http://127.0.0.1:8989/v2
+ST2_API_URL=${ST2_API_URL:-http://127.0.0.1:9101}
+MISTRAL_BASE_URL=${MISTRAL_BASE_URL:-http://127.0.0.1:8989/v2}
 
 crudini --set ${ST2_CONF} auth api_url ${ST2_API_URL}
 crudini --set ${ST2_CONF} mistral api_url ${ST2_API_URL}

--- a/runtime/entrypoint.d/add-packs-dev.sh
+++ b/runtime/entrypoint.d/add-packs-dev.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p /opt/stackstorm/packs.dev
+crudini --set /etc/st2/st2.conf content packs_base_paths /opt/stackstorm/packs.dev


### PR DESCRIPTION
Fix regression after https://github.com/StackStorm/st2-docker/commit/94d9ca12d16d202f43b2f3ad8eada29cb44fc7e0

Following envvars are used in `entrypoint-1ppc.sh` and shouldn't be overwritten:
- ST2_API_URL
- MISTRAL_BASE_URL