### PR TITLE
Create entrypoint.d/add-packs-dev.sh

### DIFF
--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -94,8 +94,7 @@ RUN mkdir -p /etc/st2/keys \
     && usermod -a -G st2 st2 && chgrp st2 /etc/st2/keys && chmod o-r /etc/st2/keys \
     && chgrp st2 /etc/st2/keys/datastore_key.json && chmod o-r /etc/st2/keys/datastore_key.json \
     && crudini --set /etc/st2/st2.conf keyvalue encryption_key_path /etc/st2/keys/datastore_key.json \
-    && crudini --set /etc/st2/st2.conf auth enable True \
-    && crudini --set /etc/st2/st2.conf content packs_base_paths /opt/stackstorm/packs.dev
+    && crudini --set /etc/st2/st2.conf auth enable True
 
 # Install redis client library for coordination backend
 # see: https://docs.stackstorm.com/latest/reference/policies.html

--- a/runtime/entrypoint.d/add-packs-dev.sh
+++ b/runtime/entrypoint.d/add-packs-dev.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+crudini --set /etc/st2/st2.conf content packs_base_paths /opt/stackstorm/packs.dev


### PR DESCRIPTION
Removal of `VOLUME /opt/stackstorm/packs.dev` from the `Dockerfile` in a previous commit was breaking 1ppc setup.