### PR TITLE
Let kubernetes decide port for st2web Service

### DIFF
--- a/runtime/kubernetes-1ppc/README.md
+++ b/runtime/kubernetes-1ppc/README.md
@@ -5,16 +5,14 @@
 Tested environment:
 
 - Mac
-    - minikube version: v0.21.0
-    - Kubernetes v1.7.0
+    - minikube version: v0.23.0
+    - Kubernetes v1.8.0
 
 ```
 # Run following commands in the same directory as this README.md
 
 # Start minikube cluster
-# Note: Allow assigning 443 for NodePort service, in order to access st2web
-minikube start --vm-driver=xhyve --extra-config=apiserver.ServiceNodePortRange=443-32767 \
-  --memory=4096 --cpus=2
+minikube start --vm-driver=xhyve --memory=4096 --cpus=2
 
 # Check cluster is ready...
 kubectl get pods --all-namespaces

--- a/runtime/kubernetes-1ppc/st2.yml
+++ b/runtime/kubernetes-1ppc/st2.yml
@@ -389,7 +389,6 @@ spec:
   ports:
   - protocol: TCP
     port: 443
-    nodePort: 443
 
 ---
 apiVersion: apps/v1beta1


### PR DESCRIPTION
st2web >= 2.5.0 supports running on port other than 443. Now we can let kubernetes decide port randomly for st2web Service, which will eliminate need of passing extra config like `--extra-config=apiserver.ServiceNodePortRange=443-32767` for minikube.