### PR TITLE
Fix connection problem between mistral-server service and rabbitmq container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - ./runtime/entrypoint.d:/st2-docker/entrypoint.d
       - ./runtime/st2.d:/st2-docker/st2.d
       - ./conf/stackstorm.env:/st2-docker/env
+    dns_search: .
 
 ### External Services
 
@@ -33,6 +34,7 @@ services:
       - private
     volumes:
       - mongo-volume:/data/db
+    dns_search: .
   rabbitmq:
     image: rabbitmq:management
     container_name: rabbitmq
@@ -42,6 +44,7 @@ services:
       - private
     volumes:
       - rabbitmq-volume:/var/lib/rabbitmq
+    dns_search: .
   postgres:
     image: postgres:latest
     container_name: postgres
@@ -51,6 +54,7 @@ services:
       - private
     volumes:
       - postgres-volume:/var/lib/postgresql/data
+    dns_search: .
   redis:
     image: redis:latest
     container_name: redis
@@ -60,6 +64,7 @@ services:
       - private
     volumes:
       - redis-volume:/data
+    dns_search: .
 
 volumes:
   mongo-volume:

--- a/runtime/compose-1ppc/docker-compose.yml
+++ b/runtime/compose-1ppc/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     restart: on-failure
     environment:
       - ST2_SERVICE=nop
+    dns_search: .
   st2api:
     <<: *base
     environment:
@@ -79,12 +80,14 @@ services:
     networks:
       - public
       - private
+
   st2web-dns:
     image: janeczku/go-dnsmasq:latest
     environment:
       - DNSMASQ_ENABLE_SEARCH=1
     networks:
       - private
+    dns_search: .
 
 ### External Services
 
@@ -96,6 +99,7 @@ services:
       - private
     volumes:
       - mongo-volume:/data/db
+    dns_search: .
   rabbitmq:
     image: rabbitmq:management
     env_file:
@@ -104,6 +108,7 @@ services:
       - private
     volumes:
       - rabbitmq-volume:/var/lib/rabbitmq
+    dns_search: .
   postgres:
     image: postgres:latest
     env_file:
@@ -112,6 +117,7 @@ services:
       - private
     volumes:
       - postgres-volume:/var/lib/postgresql/data
+    dns_search: .
   redis:
     image: redis:latest
     env_file:
@@ -120,6 +126,7 @@ services:
       - private
     volumes:
       - redis-volume:/data
+    dns_search: .
 
 volumes:
   mongo-volume:


### PR DESCRIPTION
## Symptoms

Some users (at least three) start to claim that they can't run any mistral workflows. Actions and ActionChains works fine. Through the investigation we figured out that `mistral-server` process is not connecting to `rabbitmq` at all, even it is not sending out any TCP SYN to `rabbitmq` container.

## Fix

Remove `search your.domain` line from `/etc/resolv.conf` in `stackstorm` container did solve the problem. Basically the content of `/etc/resolv.conf` in container is automatically populated by `dockerd` inheriting the one from host, but [can be overridden by passing options explicitly.](https://docs.docker.com/engine/userguide/networking/configure-dns/)

This patch will add `dns_search` option to all services defined in `docker-compose.yml` to explicitly unset `search` entry and remove it from `/etc/resolv.conf`. (Specifying `.` will do it, according to [this doc.](https://docs.docker.com/engine/userguide/networking/default_network/configure-dns/))

Note: *We still do not understand why this was causing the issue and why only `mistral-server` is affected so far.*