### PR TITLE
Replace reusable with docker_layer_caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          reusable: true
-          exclusive: true
+          docker_layer_caching: true
       - run:
           name: Install bash
           command: apk add --no-cache bash
@@ -24,8 +23,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          reusable: true
-          exclusive: true
+          docker_layer_caching: true
       - run:
           name: Install bash
           command: apk add --no-cache bash


### PR DESCRIPTION
Replace `reusable` with `docker_layer_caching` per https://circleci.com/docs/2.0/docker-layer-caching/:

> Note: The docker_layer_caching option is not yet supported in an installable CircleCI release, but this functionality is available by using the reusable: true option. Previously the docker_layer_caching was called reusable. The reusable key is deprecated in favor of the docker_layer_caching key. In addition, the exclusive option is deprecated in favor of all VMs being treated as exclusive. This indicates that jobs are guaranteed to have an exclusive Remote Docker Environment that other jobs cannot access when using docker_layer_caching.

We are also removing the `exclusive` option since it is now deprecated.