### PR TITLE
Fix redis URL in st2.conf

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,13 @@ services:
     volumes:
       - redis-volume:/data
     dns_search: .
+    command: [
+      "bash", "-c",
+      '
+       docker-entrypoint.sh
+       --requirepass "$$REDIS_PASSWORD"
+      '
+    ]
 
 volumes:
   mongo-volume:

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -23,7 +23,7 @@ crudini --set ${ST2_CONF} mistral v2_base_url ${MISTRAL_BASE_URL}
 crudini --set ${ST2_CONF} messaging url \
   amqp://${RABBITMQ_DEFAULT_USER}:${RABBITMQ_DEFAULT_PASS}@${RABBITMQ_HOST}:${RABBITMQ_PORT}
 crudini --set ${ST2_CONF} coordination url \
-  redis://${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}
+  redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}
 crudini --set ${ST2_CONF} database host ${MONGO_HOST}
 crudini --set ${ST2_CONF} database port ${MONGO_PORT}
 if [ ! -z ${MONGO_DB} ]; then

--- a/runtime/compose-1ppc/docker-compose.yml
+++ b/runtime/compose-1ppc/docker-compose.yml
@@ -127,6 +127,13 @@ services:
     volumes:
       - redis-volume:/data
     dns_search: .
+    command: [
+      "bash", "-c",
+      '
+       docker-entrypoint.sh
+       --requirepass "$$REDIS_PASSWORD"
+      '
+    ]
 
 volumes:
   mongo-volume:


### PR DESCRIPTION
There's a tiny typo in redis URL: `:` was missing before password. Because of this, redis authentication was not properly working. And also, authentication was not enabled in `library/redis` container, so we didn't notice the problem. This patch fixes both.

It turns out that #66 was caused by this bug. I could reproduce it if:
- `:` is missing in redis URL in `st2.conf`, and `redis` authentication is enabled in redis container. or,
- `:` is there in redis URL in `st2.conf` along with password, and `redis` authentication is disabled