### PR TITLE
Make /opt/stackstorm/packs persistent to survive container restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,6 @@ The default container configuration is as follows:
  - postgres
  - redis
 
-The mongo, rabbitmq, postgres and redis containers store their data
-on persistent storage. Additionally, the stackstorm container persists
-the contents of `/var/log`. If you do not wish to persist this data,
-then remove the appropriate entries from `docker-compose.yml`.
-
 ## READ FIRST!!
 
 - **Check the [CHANGELOG.rst](https://github.com/StackStorm/st2-docker/blob/master/CHANGELOG.rst)** file for any potential
@@ -100,6 +95,19 @@ To stop the docker environment, run:
   ```
   docker-compose down
   ```
+
+
+## Data persistence
+
+It's designed to suffice the ordinary use case by default. If you need to customize it, check below and modify `docker-compose.yml`
+
+- The mongo, rabbitmq, postgres and redis containers store their data on persistent storage
+- The stackstorm container persists the contents in following directories
+    - `/var/log`
+    - `/opt/stackstorm/packs`
+    - `/opt/stackstorm/virtualenvs`
+    - `/opt/stackstorm/configs`
+
 
 ## Running custom shell scripts on boot
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       - public
       - private
     volumes:
+      - stackstorm-packs-volume:/opt/stackstorm/packs
+      - stackstorm-virtualenvs-volume:/opt/stackstorm/virtualenvs
+      - stackstorm-configs-volume:/opt/stackstorm/configs
       - stackstorm-log-volume:/var/log
       - ./packs.dev:/opt/stackstorm/packs.dev
       - ./runtime/entrypoint.d:/st2-docker/entrypoint.d
@@ -71,6 +74,9 @@ volumes:
   postgres-volume:
   rabbitmq-volume:
   redis-volume:
+  stackstorm-packs-volume:
+  stackstorm-virtualenvs-volume:
+  stackstorm-configs-volume:
   stackstorm-log-volume:
 
 networks:


### PR DESCRIPTION
Some (at least two in Slack) users eventually start reporting that all packs are lost after container restart. That is not a bug, but definitely not the expected behavior for those who is new to stackstorm and/or st2-docker.

We've discussed this in #26 and still need further more discussion for handling files in `/etc`, but at least it seems it's fine to make packs persistent and survive the container restart or image upgrade.