### PR TITLE
1ppc: Use jinja template to generate nginx conf for st2web

### DIFF
--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -137,4 +137,5 @@ ENTRYPOINT ["/st2-docker/bin/entrypoint.sh"]
 RUN wget -O /dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 \
     && chmod +x /dumb-init
 COPY bin/entrypoint-1ppc.sh /st2-docker/bin/entrypoint-1ppc.sh
-COPY config/st2-1ppc.conf /etc/nginx/conf.d/st2-1ppc.cnf
+COPY bin/inject_env.py /st2-docker/bin/inject_env.py
+COPY config/nginx.st2-1ppc.conf.tpl /etc/nginx/conf.d/st2-1ppc.conf.tpl

--- a/images/stackstorm/bin/entrypoint-1ppc.sh
+++ b/images/stackstorm/bin/entrypoint-1ppc.sh
@@ -9,8 +9,10 @@ crudini --set ${ST2_CONF} mistral v2_base_url ${ST2_MISTRAL_API_URL}
 # st2api gunicorn process is directly exposed to clients in 1ppc mode
 crudini --set ${ST2_CONF} api allow_origin '*'
 
-# Overwrite nginx config for st2web to support load balancing to st2api, st2auth and st2stream
-( cd /etc/nginx/conf.d && ln -sf st2-1ppc.cnf st2.conf )
+# Generate nginx config for st2web to support load balancing to st2api, st2auth and st2stream
+/st2-docker/bin/inject_env.py \
+  < /etc/nginx/conf.d/st2-1ppc.conf.tpl \
+  > /etc/nginx/conf.d/st2.conf
 
 case "$ST2_SERVICE" in
   "nop" )

--- a/images/stackstorm/bin/inject_env.py
+++ b/images/stackstorm/bin/inject_env.py
@@ -1,0 +1,29 @@
+#!/opt/stackstorm/st2/bin/python
+
+"""
+    jinja2 template converter script
+
+    This script will accept template input from STDIN, then render output to STDOUT
+    Within a template, you can access environment variables with `env['YOUR_ENVVAR']`
+
+    Usage example:
+    env HOGE=fuga inject_env.py < template_file > output_file
+"""
+
+import os
+import sys
+import jinja2
+
+def striptrailingslash(value):
+    """
+    custom filter that strips forwarding slashes
+    """
+    return value.strip('/')
+
+# create jinja environment and add custom filters
+environment = jinja2.Environment(loader=None)
+environment.filters['striptrailingslash'] = striptrailingslash
+
+# load template string from STDIN, then render to STDOUT
+template = environment.from_string(sys.stdin.read())
+sys.stdout.write(template.render(env=os.environ))

--- a/images/stackstorm/config/nginx.st2-1ppc.conf.tpl
+++ b/images/stackstorm/config/nginx.st2-1ppc.conf.tpl
@@ -43,7 +43,7 @@ server {
   add_header              Front-End-Https on;
   add_header              X-Content-Type-Options nosniff;
 
-  resolver st2web-dns valid=10s ipv6=off;
+  resolver {{ env['ST2WEB_DNS_RESOLVER'] | default('127.0.0.1') }} valid=10s ipv6=off;
 
   location @apiError {
     add_header Content-Type application/json always;
@@ -53,7 +53,7 @@ server {
   location /api/ {
     error_page 502 = @apiError;
 
-    set $st2_api_url http://st2api:9101;
+    set $st2_api_url {{ env['ST2_API_URL'] | striptrailingslash }};
 
     rewrite ^/api/(.*)  /$1 break;
 
@@ -89,7 +89,7 @@ server {
   location /stream/ {
     error_page 502 = @streamError;
 
-    set $st2_stream_url http://st2stream:9102;
+    set $st2_stream_url {{ env['ST2_STREAM_URL'] | striptrailingslash }};
 
     rewrite ^/stream/(.*)  /$1 break;
 
@@ -119,7 +119,7 @@ server {
   location /auth/ {
     error_page 502 = @authError;
 
-    set $st2_auth_url http://st2auth:9100;
+    set $st2_auth_url {{ env['ST2_AUTH_URL'] | striptrailingslash }};
 
     rewrite ^/auth/(.*)  /$1 break;
 

--- a/runtime/compose-1ppc/README.md
+++ b/runtime/compose-1ppc/README.md
@@ -77,6 +77,12 @@ docker-compose exec st2client st2 run examples.mistral_examples
 docker-compose up --scale st2actionrunner=3 -d
 ```
 
+## Additional environment variables in 1ppc
+
+| Parameter | Description |
+|-----------|-------------|
+| `ST2WEB_DNS_RESOLVER` | *(Optional)* Hostname or address of the DNS resolver that nginx running in st2web container will use. Default is `127.0.0.1` which is suitable for sidecar pattern in Kubernetes. |
+
 ### Sharing Content
 
 See [official document](https://docs.stackstorm.com/reference/ha.html#sharing-content) for details.
@@ -91,9 +97,5 @@ See [official document](https://docs.stackstorm.com/reference/ha.html#sharing-co
 
 ### Notes
 
-- In `/etc/nginx/conf.d/st2.conf` some hostnames are hardcoded and cannot set via environment
-  variables. This means those services must be accessible by those hardcoded hostnames.
-    - `proxy_pass` directive for `st2auth`, `st2api` and `st2stream`
-    - `resolver` directive
 - Currently all inter-service connections are done via plain http, which might be a problem in
   production setup.

--- a/runtime/compose-1ppc/docker-compose.yml
+++ b/runtime/compose-1ppc/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     <<: *base
     environment:
       - ST2_SERVICE=st2web
+      - ST2WEB_DNS_RESOLVER=st2web-dns
     ports:
       - "443:443"
     networks:

--- a/runtime/kubernetes-1ppc/st2.yml
+++ b/runtime/kubernetes-1ppc/st2.yml
@@ -376,34 +376,7 @@ spec:
         - configMapRef: { name: postgres }
         ports:
         - containerPort: 443
-
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: st2web
-spec:
-  selector:
-    app: st2web
-  type: NodePort
-  ports:
-  - protocol: TCP
-    port: 443
-
----
-apiVersion: apps/v1beta1
-kind: Deployment
-metadata:
-  name: st2web-dns
-spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        app: st2web-dns
-    spec:
-      containers:
-      - name: st2web-dns
+      - name: dns-resolver
         image: janeczku/go-dnsmasq:latest
         imagePullPolicy: IfNotPresent
         env:
@@ -417,13 +390,14 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: st2web-dns
+  name: st2web
 spec:
   selector:
-    app: st2web-dns
+    app: st2web
+  type: NodePort
   ports:
-  - protocol: UDP
-    port: 53
+  - protocol: TCP
+    port: 443
 
 ---
 kind: PersistentVolumeClaim


### PR DESCRIPTION
This will eliminate all hardcoded URLs existed in nginx config file and set them from environment variables.

- Add utility script which render template with environment variables
- Introduce new environment parameter `ST2WEB_DNS_RESOLVER` to specify resolver address used by nginx
- kubernetes-1ppc now uses sidecar pattern for st2web dns resolver