### PR TITLE
Make all volume explicit and clearer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - private
     volumes:
       - mongo-volume:/data/db
+      - mongo-configdb-volume:/data/configdb
     dns_search: .
   rabbitmq:
     image: rabbitmq:management
@@ -71,6 +72,7 @@ services:
 
 volumes:
   mongo-volume:
+  mongo-configdb-volume:
   postgres-volume:
   rabbitmq-volume:
   redis-volume:

--- a/runtime/compose-1ppc/docker-compose.yml
+++ b/runtime/compose-1ppc/docker-compose.yml
@@ -99,6 +99,7 @@ services:
       - private
     volumes:
       - mongo-volume:/data/db
+      - mongo-configdb-volume:/data/configdb
     dns_search: .
   rabbitmq:
     image: rabbitmq:management
@@ -130,6 +131,7 @@ services:
 
 volumes:
   mongo-volume:
+  mongo-configdb-volume:
   postgres-volume:
   rabbitmq-volume:
   redis-volume:


### PR DESCRIPTION
After `docker-compose up` with current `docker-compose.yml`:

```
$ docker volume ls
DRIVER              VOLUME NAME
local               6b8c20faf32b6d8a641e0b6d3ae8d78ecd8c3f5f8e0cdae505c7b63e37682921
local               st2docker_mongo-volume
local               st2docker_postgres-volume
local               st2docker_rabbitmq-volume
local               st2docker_redis-volume
local               st2docker_stackstorm-configs-volume
local               st2docker_stackstorm-log-volume
local               st2docker_stackstorm-packs-volume
local               st2docker_stackstorm-virtualenvs-volume
```

The first entry is actually mounted at `/data/configdb` in `mongo` service, but obviously it is not clear.

This patch add named volume for it explicitly, and make it easier to understand.

```
$ docker volume ls
DRIVER              VOLUME NAME
local               st2docker_mongo-configdb-volume
local               st2docker_mongo-volume
local               st2docker_postgres-volume
local               st2docker_rabbitmq-volume
local               st2docker_redis-volume
local               st2docker_stackstorm-configs-volume
local               st2docker_stackstorm-log-volume
local               st2docker_stackstorm-packs-volume
local               st2docker_stackstorm-virtualenvs-volume`
```
