### PR TITLE
A change to the versioning semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ The default container configuration is as follows:
   changes that may require restarting containers.
 - Be sure to use the latest `docker-compose.yml`. Run `git pull` in your `st2-docker` workspace!
 - Run `st2ctl reload --register-all` to reload all services.
+- **For information on how the stackstorm docker image is versioned, see [VERSIONING.md](https://github.com/StackStorm/st2-docker/blob/master/VERSIONING.md)**
+- If a specific image is required, it is always best to be explicit. For example:
+  ```
+  stackstorm/stackstorm:2.5.0@{4e0e5869e784}
+  ```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The default container configuration is as follows:
 - Be sure to use the latest `docker-compose.yml`. Run `git pull` in your `st2-docker` workspace!
 - Run `st2ctl reload --register-all` to reload all services.
 - **For information on how the stackstorm docker image is versioned, see [VERSIONING.md](https://github.com/StackStorm/st2-docker/blob/master/VERSIONING.md)**
-- If a specific image is required, it is always best to be explicit. For example:
+- If a specific image is required, it is always best to be explicit and specify the Image ID. For example:
   ```
-  stackstorm/stackstorm:2.5.0@{4e0e5869e784}
+  stackstorm/stackstorm:2.5.0@{7f33f32b1495}
   ```
 
 ## Usage

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,43 +1,13 @@
-# StackStorm Image Versioning
+# StackStorm Docker Image Versioning
 
-An image with a version tag equal to a semver (e.g. `2.5.0`) is immutable. A version tag
-equal to a two digit number (e.g. `2.5`) may or may not be mutable depending on the timeline.
-A version tag equal to `latest` is always mutable.
-
-To clear up any potential confusion regarding versioning of the `stackstorm/stackstorm` image,
-we use the following table.
-
-For sake of example, assume that `2.5.0` is the latest stable StackStorm version. The image:tag
-
-Outstanding questions:
-
- - Should we be responsible for deploying security patches to images if the issue is found in the
-   base OS image? What version tag should be used? Shall we use `:2.5.0-nnn`?
- - Should we consider building and versioning a "base" `stackstorm/st2-docker` image separate from
-   the `stackstorm` image that contains a specific version of st2? Then discerning users can build
-   the precise image they want. Consider how to test st2 dependencies on the base image. While
-   flexible, this method increases maintenance burden.
+See https://github.com/StackStorm/st2-docker/issues/78 for more information.
 
 | Image:Tag | StackStorm Version | Description |
 |-----------|--------------------|-------------|
-| stackstorm:latest | 2.5.0 (latest stable version of Stackstorm) | Changes merged to `st2-docker:master` branch will result in a new image being deployed. |
-| stackstorm:2.5 | 2.5.0 | Mutable until 2.6.0 release. This tag is updated when there is a new 2.5.x or 2.5.x-nnn release. |
+| stackstorm:dev | 2.6dev | Latest 2.6dev, and most recent st2-docker changes from the st2-docker:master branch.
+| stackstorm:latest | 2.5.1 (latest stable version of Stackstorm) | Changes merged to `st2-docker:master` branch will result in a new image being deployed. |
+| stackstorm:2.5 | 2.5.1 | Mutable. This tag is updated when there is a new 2.5.x release. |
+| stackstorm:2.5.1 | 2.5.1 | Immutable, even if changes merged to `st2-docker:master` |
 | stackstorm:2.5.0 | 2.5.0 | Immutable, even if changes merged to `st2-docker:master` |
-| stackstorm:2.4 | 2.4.1 | Immutable after 2.5.0 is released |
 | stackstorm:2.4.1 | 2.4.1 | Immutable, even if changes merged to `st2-docker:master` |
 | stackstorm:2.4.0 | 2.4.0 | Immutable, even if changes merged to `st2-docker:master` |
-| stackstorm:2.3 | 2.3.2 | Immutable after 2.4.0 is released |
-| stackstorm:2.3.2 | 2.3.2 | Immutable, even if changes merged to `st2-docker:master` |
-| stackstorm:2.3.1 | 2.3.1 | Immutable, even if changes merged to `st2-docker:master` |
-| stackstorm:2.3.0 | 2.3.0 | Immutable, even if changes merged to `st2-docker:master` |
-
-More thought needs to be given to the `stackstorm/stackstorm-dev` image. Here are the latest
-thoughts:
-
-| Image:Tag | StackStorm Version | Description |
-|-----------|--------------------|-------------|
-| stackstorm-dev:latest | 2.6dev (latest unstable version of StackStorm) | Plus any changes merged to `st2-docker:master` branch. |
-| stackstorm-dev:2.6-20171111 | (latest unstable version of Stackstorm at build time) | Immutable, even if changes merged to `st2-docker:master` |
-| stackstorm-dev:2.6-20171110 | (latest unstable version of Stackstorm at build time) | Immutable, even if changes merged to `st2-docker:master` |
-| ... | ... | ... |
-

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -9,5 +9,6 @@ See https://github.com/StackStorm/st2-docker/issues/78 for more information.
 | stackstorm:2.5 | 2.5.1 | Mutable. This tag is updated when there is a new 2.5.x release. |
 | stackstorm:2.5.1 | 2.5.1 | Immutable, even if changes merged to `st2-docker:master` |
 | stackstorm:2.5.0 | 2.5.0 | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm:2.4 | 2.4.1 | Mutable. This tag is updated when there is a new 2.4.x release. |
 | stackstorm:2.4.1 | 2.4.1 | Immutable, even if changes merged to `st2-docker:master` |
 | stackstorm:2.4.0 | 2.4.0 | Immutable, even if changes merged to `st2-docker:master` |

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,43 @@
+# StackStorm Image Versioning
+
+An image with a version tag equal to a semver (e.g. `2.5.0`) is immutable. A version tag
+equal to a two digit number (e.g. `2.5`) may or may not be mutable depending on the timeline.
+A version tag equal to `latest` is always mutable.
+
+To clear up any potential confusion regarding versioning of the `stackstorm/stackstorm` image,
+we use the following table.
+
+For sake of example, assume that `2.5.0` is the latest stable StackStorm version. The image:tag
+
+Outstanding questions:
+
+ - Should we be responsible for deploying security patches to images if the issue is found in the
+   base OS image? What version tag should be used? Shall we use `:2.5.0-nnn`?
+ - Should we consider building and versioning a "base" `stackstorm/st2-docker` image separate from
+   the `stackstorm` image that contains a specific version of st2? Then discerning users can build
+   the precise image they want. Consider how to test st2 dependencies on the base image. While
+   flexible, this method increases maintenance burden.
+
+| Image:Tag | StackStorm Version | Description |
+|-----------|--------------------|-------------|
+| stackstorm:latest | 2.5.0 (latest stable version of Stackstorm) | Changes merged to `st2-docker:master` branch will result in a new image being deployed. |
+| stackstorm:2.5 | 2.5.0 | Mutable until 2.6.0 release. This tag is updated when there is a new 2.5.x or 2.5.x-nnn release. |
+| stackstorm:2.5.0 | 2.5.0 | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm:2.4 | 2.4.1 | Immutable after 2.5.0 is released |
+| stackstorm:2.4.1 | 2.4.1 | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm:2.4.0 | 2.4.0 | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm:2.3 | 2.3.2 | Immutable after 2.4.0 is released |
+| stackstorm:2.3.2 | 2.3.2 | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm:2.3.1 | 2.3.1 | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm:2.3.0 | 2.3.0 | Immutable, even if changes merged to `st2-docker:master` |
+
+More thought needs to be given to the `stackstorm/stackstorm-dev` image. Here are the latest
+thoughts:
+
+| Image:Tag | StackStorm Version | Description |
+|-----------|--------------------|-------------|
+| stackstorm-dev:latest | 2.6dev (latest unstable version of StackStorm) | Plus any changes merged to `st2-docker:master` branch. |
+| stackstorm-dev:2.6-20171111 | (latest unstable version of Stackstorm at build time) | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm-dev:2.6-20171110 | (latest unstable version of Stackstorm at build time) | Immutable, even if changes merged to `st2-docker:master` |
+| ... | ... | ... |
+

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,29 +1,6 @@
 #!/bin/bash
 #
 # This script runs within the CircleCI environment to build stackstorm images.
-#
-# Generally speaking, we only maintain the image containing the latest release
-# of StackStorm tagged in the st2-docker repo. To build an image with a
-# specific release of StackStorm, push an annotated tag of the format "vX.Y.Z",
-# where "v" is literal, and "X.Y.Z" is the release number. The tag will be made
-# available within CircleCI using the $CIRCLE_TAG environment variable.
-#
-# If $CIRCLE_TAG has zero length, then no tag was pushed. The following image
-# will be built:
-#
-#   stackstorm/stackstorm:X.Y.Z   (where X.Y.Z is the latest StackStorm release)
-#
-# If this image was already built, then it will be built again (using a
-# potentially different Dockerfile). The image is only guaranteed to contain
-# the specified StackStorm release.
-#
-# If X.Y.Z is the latest release, the following target image is set to refer
-# to the above image:
-#
-#   stackstorm/stackstorm:latest
-#
-# If BUILD_DEV environment variable is defined, this triggers an image build based
-# on unstable.
 
 set -euo pipefail
 IDS=$'\n\t'
@@ -63,11 +40,13 @@ echo tag=${tag}
 for name in stackstorm; do
   if [ -z ${BUILD_DEV:-} ]; then
     # This is not a dev build
+    if [[ ! -z ${CIRCLE_TAG:-} ]]; then
     docker build --build-arg ST2_TAG=${tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1:-} \
       --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
       --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
       --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \
       -t stackstorm/${name}:${tag} images/${name}
+    fi
 
     if [ "v${tag}" == "${latest}" ]; then
       docker tag stackstorm/${name}:${tag} stackstorm/${name}:latest

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,30 +1,7 @@
 #!/bin/bash
 #
-# This script runs within the CircleCI environment to build and deploy
-# st2-docker images to Docker Hub.
-#
-# Generally speaking, we only maintain the image containing the latest release
-# of StackStorm tagged in the st2-docker repo. To build an image with a
-# specific release of StackStorm, push an annotated tag of the format "vX.Y.Z",
-# where "v" is literal, and "X.Y.Z" is the release number. The tag will be made
-# available within CircleCI using the $CIRCLE_TAG environment variable.
-#
-# If $CIRCLE_TAG has zero length, then no tag was pushed. The following image
-# will be built:
-#
-#   stackstorm/stackstorm:X.Y.Z   (where X.Y.Z is the latest StackStorm release)
-#
-# If this image was already built, then it will be built again (using a
-# potentially different Dockerfile). The image is only guaranteed to contain
-# the specified StackStorm release.
-#
-# If X.Y.Z is the latest release, the following target image is set to refer
-# to the above image:
-#
-#   stackstorm/stackstorm:latest
-#
-# If BUILD_DEV environment variable is defined, this triggers an image build based
-# on unstable.
+# This script runs within the CircleCI environment to deploy st2-docker images
+# to Docker Hub.
 
 set -euo pipefail
 IDS=$'\n\t'
@@ -45,35 +22,29 @@ echo latest=${latest}
 if [[ ${CIRCLE_TAG:-} =~ ^v(.+)$ ]]; then
   # A tag was pushed, so we'll build an image using this specific release.
   tag=${BASH_REMATCH[1]}
-else
-  # Build and tag an image using the latest StackStorm release
-  if [[ ${latest} =~ ^v(.+)$ ]]; then
-    tag=${BASH_REMATCH[1]}
-  else
-    echo "ERROR: Could not find a git tag in the st2-docker repo with format vX.Y.Z"
-    echo "To resolve, run:"
-    echo "  $ git co master"
-    echo "  $ git tag -a 'vX.Y.Z' -m 'Stamping X.Y.Z' HEAD"
-    echo "  $ git push --tags"
-    exit 1
-  fi
 fi
 
-echo tag=${tag}
+tag=${tag:-}
 
 for name in stackstorm; do
   if [ -z ${BUILD_DEV:-} ]; then
-    # This is not a dev build
-    docker push stackstorm/${name}:${tag}
+    # This is not a dev build!
 
-    if [ "v${tag}" == "${latest}" ]; then
-      docker tag stackstorm/${name}:${tag} stackstorm/${name}:latest
-      docker push stackstorm/${name}:latest
-    else
-      echo "v${tag} != ${latest}"
+    # Push the tag to docker hub if and only if this is a tagged build.
+    # ASSUMPTION: Builds are never "re-tagged".
+    if [ ! -z ${CIRCLE_TAG:-} ]; then
+      docker push stackstorm/${name}:${tag}
+
+      if [ "${CIRCLE_TAG}" == "${latest}" ]; then
+        # Update latest if and only if the tag is the most recent tag.
+        # ASSUMPTION: Tags are applied in monotonically increasing order.
+        docker tag stackstorm/${name}:${tag} stackstorm/${name}:latest
+        docker push stackstorm/${name}:latest
+      else
+        echo "Not deploying image. ${CIRCLE_TAG} != ${latest}"
+      fi
     fi
   else
-    # Triggered to run nightly via ops-infra
     # Build unstable, and tag as "dev".
 
     # TODO: Potentially useful to prepend "dev" with revision of latest unstable


### PR DESCRIPTION
Resolves #78 

Today, the versioning semantics of the stackstorm/stackstorm docker image do not meet the requirements of all users. In particular, whenever we merge changes to the st2-docker:master branch, CircleCI builds and deploys two images to docker hub. The first image has a version tag based on the most recent git tag in the st2-docker repo, and the second image has a version tag equal to latest. The problem is that the former image changes fairly regularly - which is not desired. The recommendation is that images with a semver-based version tag should be immutable.

Having said the above, if a specific image is required, it is best to be explicit and specify the Image ID. For example:

```
stackstorm/stackstorm:2.5.0@{7f33f32b1495}
```

This way, even if the image tagged 2.5.0 ever changed, you would still get the image with the specified hash.
  