### PR TITLE
Install examples only once.

### DIFF
--- a/runtime/st2.d/virtualenv.sh
+++ b/runtime/st2.d/virtualenv.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
+EXAMPLES=/opt/stackstorm/packs/examples
 
-cp -R /usr/share/doc/st2/examples /opt/stackstorm/packs
-chgrp -R st2packs /opt/stackstorm/packs/examples
-st2 run packs.setup_virtualenv packs=examples
+if [ ! -d "$EXAMPLES" ]; then
+	echo "Installing examples..."
+  cp -R /usr/share/doc/st2/examples /opt/stackstorm/packs
+  chgrp -R st2packs /opt/stackstorm/packs/examples
+  st2 run packs.setup_virtualenv packs=examples
+fi

--- a/runtime/st2.d/virtualenv.sh
+++ b/runtime/st2.d/virtualenv.sh
@@ -2,7 +2,7 @@
 EXAMPLES=/opt/stackstorm/packs/examples
 
 if [ ! -d "$EXAMPLES" ]; then
-	echo "Installing examples..."
+  echo "Installing examples..."
   cp -R /usr/share/doc/st2/examples /opt/stackstorm/packs
   chgrp -R st2packs /opt/stackstorm/packs/examples
   st2 run packs.setup_virtualenv packs=examples


### PR DESCRIPTION
Problem: `st2.d/virtualenv.sh` runs on every `docker-compose up`. 
Not dangerous but it pollutes the history and is just not the right thing. 

Solution: Skip installing examples if they're already in place. 
