### PR TITLE
Fix the container name for redis.yml

### DIFF
--- a/runtime/kubernetes-1ppc/externals/redis.yml
+++ b/runtime/kubernetes-1ppc/externals/redis.yml
@@ -11,7 +11,7 @@ spec:
         app: redis
     spec:
       containers:
-      - name: nginx
+      - name: redis
         image: redis:latest
         ports:
         - containerPort: 6379


### PR DESCRIPTION
The previous container name is incorrect in redis.yml 