### PR TITLE
Set stty size

### DIFF
--- a/runtime/entrypoint.d/sttysize.sh
+++ b/runtime/entrypoint.d/sttysize.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+RC=${HOME}/.bashrc
+SNIPPET=/st2-docker/entrypoint.d/sttysize.snippet
+
+if ! grep -q sttysize ${RC}; then
+  echo >> ${RC}
+  echo "[ -r ${SNIPPET} ] && . ${SNIPPET}" >> ${RC}
+fi

--- a/runtime/entrypoint.d/sttysize.snippet
+++ b/runtime/entrypoint.d/sttysize.snippet
@@ -1,3 +1,6 @@
+# Ensure the entire terminal is used. This particular code comes from
+#  https://gist.github.com/scentoni/f4bda3a07cf7711125de3928f95809af
+
 res() {
 
   old=$(stty -g)
@@ -8,8 +11,6 @@ res() {
 
   stty "$old"
 
-  # echo "cols:$cols"
-  # echo "rows:$rows"
   stty cols "$cols" rows "$rows"
 }
 

--- a/runtime/entrypoint.d/sttysize.snippet
+++ b/runtime/entrypoint.d/sttysize.snippet
@@ -1,0 +1,16 @@
+res() {
+
+  old=$(stty -g)
+  stty raw -echo min 0 time 5
+
+  printf '\033[18t' > /dev/tty
+  IFS=';t' read -r _ rows cols _ < /dev/tty
+
+  stty "$old"
+
+  # echo "cols:$cols"
+  # echo "rows:$rows"
+  stty cols "$cols" rows "$rows"
+}
+
+res


### PR DESCRIPTION
Without this change, in the stackstorm container `stty size` returns `0 0` and potentially only part of the terminal window is used. Use `stty` to set the actual number of `cols` and `rows` so the entire terminal window is available for use.