### PR TITLE
Use circleci to build nightly dev build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,36 @@ defaults: &defaults
 
 version: 2
 jobs:
+  nightly-build:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Install bash
+          command: apk add --no-cache bash
+      - run:
+          name: Build image
+          command: bin/build.sh
+          environment:
+            BUILD_DEV: true
+  nightly-deploy:
+    <<: *defaults
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Install bash
+          command: apk add --no-cache bash
+      - run:
+          name: Deploy image to Docker Hub
+          command: |
+            docker login --username ${DOCKER_USER} --password ${DOCKER_PASSWORD}
+            bin/deploy.sh
+          environment:
+            BUILD_DEV: true
   build:
     <<: *defaults
     steps:
@@ -44,16 +74,12 @@ workflows:
               only:
                 - master
     jobs:
-      - build:
-          environment:
-            BUILD_DEV: "dev build"
+      - nightly-build:
           filters:
             tags:
               only:
                 - /.*/
-      - deploy:
-          environment:
-            BUILD_DEV: "dev build"
+      - nightly-deploy:
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,35 @@ jobs:
 
 workflows:
   version: 2
-  build_deploy:
+  nightly-workflow:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - build:
+          environment:
+            BUILD_DEV: "dev build"
+          filters:
+            tags:
+              only:
+                - /.*/
+      - deploy:
+          environment:
+            BUILD_DEV: "dev build"
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master
+            tags:
+              only:
+                - /^v.*/
+  commit-workflow:
     jobs:
       - build:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ workflows:
                 - /.*/
       - nightly-deploy:
           requires:
-            - build
+            - nightly-build
           filters:
             branches:
               only:


### PR DESCRIPTION
Currently we use TravisCI to build the nightly dev build since CircleCI didn't have the capability to schedule builds. We now take advantage of the new functionality in CircleCI to run scheduled builds.

It'd be great if we could reduce the amount of new code. One way to do this would be to specify environment variables in the workflow, however, this is only supported via context (and I currently do not have access to set the context).

https://circleci.com/docs/2.0/workflows/#scheduling-a-workflow