### PR TITLE
Ensure newest stackstorm/stackstorm image is deployed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,15 +20,29 @@ jobs:
           command: bin/build.sh
           environment:
             BUILD_DEV: true
+      - run:
+          name: Save image
+          command: bin/save.sh
+          environment:
+            BUILD_DEV: true
+      - persist_to_workspace:
+          root: tar
+          paths:
+            - .
   nightly-deploy:
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: tar
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
           name: Install bash
           command: apk add --no-cache bash
+      - run:
+          name: Load image
+          command: bin/load.sh
       - run:
           name: Deploy image to Docker Hub
           command: |
@@ -48,15 +62,27 @@ jobs:
       - run:
           name: Build image
           command: bin/build.sh
+      - run:
+          name: Save image
+          command: bin/save.sh
+      - persist_to_workspace:
+          root: tar
+          paths:
+            - .
   deploy:
     <<: *defaults
     steps:
+      - attach_workspace:
+          at: tar
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
           name: Install bash
           command: apk add --no-cache bash
+      - run:
+          name: Load image from workspace
+          command: bin/load.sh
       - run:
           name: Deploy image to Docker Hub
           command: |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHA := $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty=*)
 
 build:
-	docker build --build-arg CIRCLE_SHA1="$(SHA)" -t stackstorm/stackstorm images/stackstorm
+	docker build --build-arg CIRCLE_SHA1="$(SHA)" -t stackstorm/stackstorm:latest images/stackstorm
 
 env:
 	bin/write-env.sh conf

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHA := $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty=*)
 
 build:
-	docker build --build-arg CIRCLE_SHA1="$(SHA)" -t stackstorm/stackstorm:latest images/stackstorm
+	docker build --build-arg CIRCLE_SHA1="$(SHA)" -t stackstorm/stackstorm images/stackstorm
 
 env:
 	bin/write-env.sh conf

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 ## TL;DR
 
 ```
+git clone git@github.com:stackstorm/st2-docker
+cd st2-docker
 make env
 docker-compose up -d
 docker-compose exec stackstorm bash

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -4,11 +4,17 @@ See https://github.com/StackStorm/st2-docker/issues/78 for more information.
 
 | Image:Tag | StackStorm Version | Description |
 |-----------|--------------------|-------------|
-| stackstorm:dev | 2.6dev | Latest 2.6dev, and most recent st2-docker changes from the st2-docker:master branch.
-| stackstorm:latest | 2.5.1 (latest stable version of Stackstorm) | Changes merged to `st2-docker:master` branch will result in a new image being deployed. |
+| stackstorm:dev | 2.7dev | Latest 2.7dev, and most recent st2-docker changes from the st2-docker:master branch. |
+| stackstorm:latest | 2.6.0 (latest stable version of Stackstorm) | Changes merged to `st2-docker:master` branch will result in a new image being deployed tagged 'latest'. |
+| stackstorm:master | 2.6.0 (latest stable version of StackStorm) | Changes merged to `st2-docker:master` branch will result in a new image being deployed tagged 'master'. |
+| stackstorm:2.6 | 2.6.0 | Mutable. This tag is updated when there is a new 2.6.x release. |
+| stackstorm:2.6.0 | 2.6.0 | Immutable, even if changes merged to `st2-docker:master` |
 | stackstorm:2.5 | 2.5.1 | Mutable. This tag is updated when there is a new 2.5.x release. |
 | stackstorm:2.5.1 | 2.5.1 | Immutable, even if changes merged to `st2-docker:master` |
 | stackstorm:2.5.0 | 2.5.0 | Immutable, even if changes merged to `st2-docker:master` |
 | stackstorm:2.4 | 2.4.1 | Mutable. This tag is updated when there is a new 2.4.x release. |
 | stackstorm:2.4.1 | 2.4.1 | Immutable, even if changes merged to `st2-docker:master` |
 | stackstorm:2.4.0 | 2.4.0 | Immutable, even if changes merged to `st2-docker:master` |
+
+http://container-solutions.com/docker-latest-confusion/
+https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -4,17 +4,13 @@ See https://github.com/StackStorm/st2-docker/issues/78 for more information.
 
 | Image:Tag | StackStorm Version | Description |
 |-----------|--------------------|-------------|
-| stackstorm:dev | 2.7dev | Latest 2.7dev, and most recent st2-docker changes from the st2-docker:master branch. |
-| stackstorm:latest | 2.6.0 (latest stable version of Stackstorm) | Changes merged to `st2-docker:master` branch will result in a new image being deployed tagged 'latest'. |
-| stackstorm:master | 2.6.0 (latest stable version of StackStorm) | Changes merged to `st2-docker:master` branch will result in a new image being deployed tagged 'master'. |
+| stackstorm:dev | 2.7dev | Latest 2.7dev, and most recent st2-docker changes from the st2-docker `master` branch. |
+| stackstorm:latest | 2.6.0 (latest stable version of Stackstorm) | Changes merged to st2-docker `master` branch will result in a new image being deployed tagged 'latest'. |
 | stackstorm:2.6 | 2.6.0 | Mutable. This tag is updated when there is a new 2.6.x release. |
-| stackstorm:2.6.0 | 2.6.0 | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm:2.6.0 | 2.6.0 | Immutable, even if changes merged to st2-docker `master` branch |
 | stackstorm:2.5 | 2.5.1 | Mutable. This tag is updated when there is a new 2.5.x release. |
-| stackstorm:2.5.1 | 2.5.1 | Immutable, even if changes merged to `st2-docker:master` |
-| stackstorm:2.5.0 | 2.5.0 | Immutable, even if changes merged to `st2-docker:master` |
+| stackstorm:2.5.1 | 2.5.1 | Immutable, even if changes merged to st2-docker `master` branch |
+| stackstorm:2.5.0 | 2.5.0 | Immutable, even if changes merged to st2-docker `master` branch |
 | stackstorm:2.4 | 2.4.1 | Mutable. This tag is updated when there is a new 2.4.x release. |
-| stackstorm:2.4.1 | 2.4.1 | Immutable, even if changes merged to `st2-docker:master` |
-| stackstorm:2.4.0 | 2.4.0 | Immutable, even if changes merged to `st2-docker:master` |
-
-http://container-solutions.com/docker-latest-confusion/
-https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375
+| stackstorm:2.4.1 | 2.4.1 | Immutable, even if changes merged to st2-docker `master` branch |
+| stackstorm:2.4.0 | 2.4.0 | Immutable, even if changes merged to st2-docker `master` branch |

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -38,8 +38,9 @@ for name in stackstorm; do
     fi
 
     if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${CIRCLE_BRANCH}
+      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:master
     fi
+
     if [ ! -z ${tag} ]; then
       ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}
     fi

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -40,7 +40,7 @@ for name in stackstorm; do
     -t stackstorm/${name_tag} images/${name}
 
   if [ "v${tag}" == "${latest}" ]; then
-    ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag:-}
+    ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag}
   else
     echo "INFO: Short tag is unchanged since this is not a tagged build."
   fi

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -5,55 +5,9 @@
 set -euo pipefail
 IDS=$'\n\t'
 
-CIRCLE_SHA1=${CIRCLE_SHA1:-}
-echo CIRCLE_SHA1=${CIRCLE_SHA1}
+source bin/common.sh
 
-CIRCLE_TAG=${CIRCLE_TAG:-}
-echo CIRCLE_TAG=${CIRCLE_TAG}
-
-BUILD_DEV=${BUILD_DEV:-}
-echo BUILD_DEV=${BUILD_DEV}
-
-if [ -z ${CIRCLE_SHA1} ]; then
-  echo "ERROR: CIRCLE_SHA1 is not defined."
-  echo "To resolve, run:"
-  echo "  $ export CIRCLE_SHA1=<commit_sha>"
-  echo "  $ $0"
-  exit 1
-fi
-
-# Get the latest tag beginning with 'v'
-latest=`git tag -l "v*" | sort -r | head -1`
-echo latest=${latest}
-
-if [ ! -z ${CIRCLE_TAG} ]; then
-  if [[ ! ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
-    echo "ERROR: CIRCLE_TAG must begin with 'v'"
-    exit 1
-  fi
-fi
-
-if [[ ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
-  # A tag was pushed, so we'll build an image using this specific release.
-  tag=${BASH_REMATCH[1]}
-  if [[ ${CIRCLE_TAG} =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    short_tag="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-  fi
-else
-  # Build and tag an image using the latest StackStorm release
-  if [[ ${latest} =~ ^v(.+)$ ]]; then
-    tag=${BASH_REMATCH[1]}
-  else
-    echo "ERROR: Could not find a git tag in the st2-docker repo with format vX.Y.Z"
-    echo "To resolve, run:"
-    echo "  $ git co master"
-    echo "  $ git tag -a 'vX.Y.Z' -m 'Stamping X.Y.Z' HEAD"
-    echo "  $ git push --tags"
-    exit 1
-  fi
-fi
-
-echo tag=${tag}
+# NOTE: dry_run=echo if the -n option is specified when executing this script
 
 for name in stackstorm; do
   if [ -z ${BUILD_DEV} ]; then
@@ -61,26 +15,33 @@ for name in stackstorm; do
     st2_tag=${tag}
 
     if [ -z ${CIRCLE_TAG} ]; then
-      # A tag was not pushed, so we only need to build 'latest'
+      # A tag was not pushed, so we only need to build 'latest' (not tagged)
       tag=''
       colon=''
     else
-      tag="${tag}"
       colon=':'
     fi
 
     name_tag="${name}${colon}${tag}"
 
-    docker build --build-arg ST2_TAG=${st2_tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
+    # Build the image, tag using CIRCLE_TAG
+    ${dry_run} docker build --build-arg ST2_TAG=${st2_tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
       --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
       --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
       --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \
       -t stackstorm/${name_tag} images/${name}
 
     if [ "v${tag}" == "${latest}" ]; then
-      docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag:-}
+      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag:-}
     else
-      echo "No need to tag build with two digit tag (v${tag} != ${latest})"
+      echo "INFO: Short tag is unchanged since this is not a tagged build."
+    fi
+
+    if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
+      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${CIRCLE_BRANCH}
+    fi
+    if [ ! -z ${tag} ]; then
+      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}
     fi
   else
     # Triggered to run nightly via ops-infra
@@ -89,7 +50,7 @@ for name in stackstorm; do
     # TODO: Potentially useful to prepend "dev" with revision of latest unstable
     #       release (e.g. "2.4dev")
 
-    docker build --build-arg ST2_REPO=unstable --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
+    ${dry_run} docker build --build-arg ST2_REPO=unstable --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
       --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
       --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
       --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -8,44 +8,43 @@ IDS=$'\n\t'
 source bin/common.sh
 
 for name in stackstorm; do
-  if [ -z ${BUILD_DEV} ]; then
-    # This is not a dev build
-    st2_tag=${tag}
-
-    if [ -z ${CIRCLE_TAG} ]; then
-      # A tag was not pushed, so we only need to build 'latest' (not tagged)
-      tag='latest'
-    fi
-
-    name_tag="${name}:${tag}"
-
-    # Build the image, tag using CIRCLE_TAG
-    ${dry_run} docker build --build-arg ST2_TAG=${st2_tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
-      --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
-      --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
-      --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \
-      -t stackstorm/${name_tag} images/${name}
-
-    if [ "v${tag}" == "${latest}" ]; then
-      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag:-}
-    else
-      echo "INFO: Short tag is unchanged since this is not a tagged build."
-    fi
-
-    if [ "$tag" != 'latest' ]; then
-      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:latest
-    fi
-  else
+  if [ ! -z ${BUILD_DEV} ]; then
     # Triggered to run nightly via ops-infra
     # Build unstable, and tag as "dev".
-
-    # TODO: Potentially useful to prepend "dev" with revision of latest unstable
-    #       release (e.g. "2.4dev")
 
     ${dry_run} docker build --build-arg ST2_REPO=unstable --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
       --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
       --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
       --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \
       -t stackstorm/${name}:dev images/${name}
+
+    continue
+  fi
+
+  # This is not a dev build
+  st2_tag=${tag}
+
+  if [ -z ${CIRCLE_TAG} ]; then
+    # A tag was not pushed, so we only need to build 'latest' (not tagged)
+    tag='latest'
+  fi
+
+  name_tag="${name}:${tag}"
+
+  # Build the image, tag using CIRCLE_TAG
+  ${dry_run} docker build --build-arg ST2_TAG=${st2_tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
+    --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
+    --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
+    --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \
+    -t stackstorm/${name_tag} images/${name}
+
+  if [ "v${tag}" == "${latest}" ]; then
+    ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag:-}
+  else
+    echo "INFO: Short tag is unchanged since this is not a tagged build."
+  fi
+
+  if [ "$tag" != 'latest' ]; then
+    ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:latest
   fi
 done

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -21,7 +21,8 @@ for name in stackstorm; do
     continue
   fi
 
-  # This is not a dev build
+  # From this point on, not a dev build...
+
   st2_tag=${tag}
 
   if [ -z ${CIRCLE_TAG} ]; then

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -7,8 +7,6 @@ IDS=$'\n\t'
 
 source bin/common.sh
 
-# NOTE: dry_run=echo if the -n option is specified when executing this script
-
 for name in stackstorm; do
   if [ -z ${BUILD_DEV} ]; then
     # This is not a dev build
@@ -16,13 +14,10 @@ for name in stackstorm; do
 
     if [ -z ${CIRCLE_TAG} ]; then
       # A tag was not pushed, so we only need to build 'latest' (not tagged)
-      tag=''
-      colon=''
-    else
-      colon=':'
+      tag='latest'
     fi
 
-    name_tag="${name}${colon}${tag}"
+    name_tag="${name}:${tag}"
 
     # Build the image, tag using CIRCLE_TAG
     ${dry_run} docker build --build-arg ST2_TAG=${st2_tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
@@ -37,12 +32,8 @@ for name in stackstorm; do
       echo "INFO: Short tag is unchanged since this is not a tagged build."
     fi
 
-    if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:master
-    fi
-
-    if [ ! -z ${tag} ]; then
-      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}
+    if [ "$tag" != 'latest' ]; then
+      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:latest
     fi
   else
     # Triggered to run nightly via ops-infra

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,0 +1,59 @@
+# The following code snippet is used by build.sh and deploy.sh
+
+# Set debug to 'echo' to test
+dry_run='echo'
+
+CIRCLE_SHA1=${CIRCLE_SHA1:-}
+echo CIRCLE_SHA1=${CIRCLE_SHA1}
+
+CIRCLE_TAG=${CIRCLE_TAG:-}
+echo CIRCLE_TAG=${CIRCLE_TAG}
+
+BUILD_DEV=${BUILD_DEV:-}
+echo BUILD_DEV=${BUILD_DEV}
+
+CIRCLE_BRANCH=${CIRCLE_BRANCH:-}
+echo CIRCLE_BRANCH=${CIRCLE_BRANCH}
+
+if [ -z ${CIRCLE_SHA1} ]; then
+  echo "ERROR: CIRCLE_SHA1 is not defined."
+  echo "To resolve, run:"
+  echo "  $ export CIRCLE_SHA1=<commit_sha>"
+  echo "  $ $0"
+  exit 1
+fi
+
+# Get the latest tag beginning with 'v'
+latest=`git tag -l "v*" | sort -r | head -1`
+echo latest=${latest}
+
+if [ ! -z ${CIRCLE_TAG} ]; then
+  if [[ ! ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
+    echo "ERROR: CIRCLE_TAG must begin with 'v'"
+    exit 1
+  fi
+fi
+
+short_tag=''
+
+if [[ ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
+  # A tag was pushed, so we'll build an image using this specific release.
+  tag=${BASH_REMATCH[1]}
+  if [[ ${CIRCLE_TAG} =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    short_tag="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+  fi
+else
+  # Build and tag an image using the latest StackStorm release
+  if [[ ${latest} =~ ^v(.+)$ ]]; then
+    tag=${BASH_REMATCH[1]}
+  else
+    echo "ERROR: Could not find a git tag in the st2-docker repo with format vX.Y.Z"
+    echo "To resolve, run:"
+    echo "  $ git co master"
+    echo "  $ git tag -a 'vX.Y.Z' -m 'Stamping X.Y.Z' HEAD"
+    echo "  $ git push --tags"
+    exit 1
+  fi
+fi
+
+echo tag=${tag}

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,7 +1,7 @@
 # The following code snippet is used by build.sh and deploy.sh
 
 # Set debug to 'echo' to test
-dry_run='echo'
+dry_run=''
 
 CIRCLE_SHA1=${CIRCLE_SHA1:-}
 echo CIRCLE_SHA1=${CIRCLE_SHA1}

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -12,9 +12,6 @@ echo CIRCLE_TAG=${CIRCLE_TAG}
 BUILD_DEV=${BUILD_DEV:-}
 echo BUILD_DEV=${BUILD_DEV}
 
-CIRCLE_BRANCH=${CIRCLE_BRANCH:-}
-echo CIRCLE_BRANCH=${CIRCLE_BRANCH}
-
 if [ -z ${CIRCLE_SHA1} ]; then
   echo "ERROR: CIRCLE_SHA1 is not defined."
   echo "To resolve, run:"

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -2,6 +2,11 @@
 
 # Set debug to 'echo' to test
 dry_run=''
+if [ ${DRY_RUN:-} ]; then
+  dry_run='echo'
+  echo "Dry run mode enabled..."
+  sleep 2
+fi
 
 CIRCLE_SHA1=${CIRCLE_SHA1:-}
 echo CIRCLE_SHA1=${CIRCLE_SHA1}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -18,9 +18,7 @@ for name in stackstorm; do
     continue
   fi
 
-  echo "not a dev build"
-
-  # This is not a dev build!
+  # From this point on, not a dev build...
 
   # Push the tag to docker hub if and only if this is a tagged build.
   # ASSUMPTION: Builds are never "re-tagged".

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -25,16 +25,9 @@ for name in stackstorm; do
       else
         echo "Not deploying image. ${CIRCLE_TAG} != ${latest}"
       fi
+    else
+      ${dry_run} docker push stackstorm/${name}:latest
     fi
-
-    # Tag with 'master' if current branch is master
-    if [[ "${CIRCLE_BRANCH}" == "master" ]]; then
-      ${dry_run} docker push stackstorm/${name}:master
-    fi
-
-    # 'latest' simply means "the last build/tag that ran without a specific tag/version specified".
-    # https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375
-    ${dry_run} docker push stackstorm/${name}
   else
     # Build unstable, and tag as "dev".
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -9,30 +9,33 @@ IDS=$'\n\t'
 source bin/common.sh
 
 for name in stackstorm; do
-  if [ -z ${BUILD_DEV} ]; then
-    # This is not a dev build!
-
-    # Push the tag to docker hub if and only if this is a tagged build.
-    # ASSUMPTION: Builds are never "re-tagged".
-    if [ ! -z ${CIRCLE_TAG} ]; then
-      if [ "${CIRCLE_TAG}" == "${latest}" ]; then
-        # Update latest if and only if the tag is the most recent tag.
-        # ASSUMPTION: Tags are applied in monotonically increasing order.
-        ${dry_run} docker push stackstorm/${name}:${tag}
-        if [ ! -z "${short_tag}" ]; then
-          ${dry_run} docker push stackstorm/${name}:${short_tag}
-        fi
-      else
-        echo "Not deploying image. ${CIRCLE_TAG} != ${latest}"
-      fi
-    else
-      ${dry_run} docker push stackstorm/${name}:latest
-    fi
-  else
+  if [ ! -z ${BUILD_DEV} ]; then
     # Build unstable, and tag as "dev".
 
     # TODO: Potentially useful to prepend "dev" with revision of latest unstable
     #       release (e.g. "2.4dev")
     ${dry_run} docker push stackstorm/${name}:dev
+    continue
+  fi
+
+  echo "not a dev build"
+
+  # This is not a dev build!
+
+  # Push the tag to docker hub if and only if this is a tagged build.
+  # ASSUMPTION: Builds are never "re-tagged".
+  if [ ! -z ${CIRCLE_TAG} ]; then
+    if [ "${CIRCLE_TAG}" == "${latest}" ]; then
+      # Update latest if and only if the tag is the most recent tag.
+      # ASSUMPTION: Tags are applied in monotonically increasing order.
+      ${dry_run} docker push stackstorm/${name}:${tag}
+      if [ ! -z "${short_tag}" ]; then
+        ${dry_run} docker push stackstorm/${name}:${short_tag}
+      fi
+    else
+      echo "Not deploying image. ${CIRCLE_TAG} != ${latest}"
+    fi
+  else
+    ${dry_run} docker push stackstorm/${name}:latest
   fi
 done

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -55,12 +55,12 @@ for name in stackstorm; do
         if [ ! -z "${short_tag:-}" ]; then
           docker push stackstorm/${name}:${short_tag}
         fi
-        docker push stackstorm/${name}:latest
+        docker push stackstorm/${name}
       else
         echo "Not deploying image. ${CIRCLE_TAG} != ${latest}"
       fi
     else
-      docker push stackstorm/${name}:latest
+      docker push stackstorm/${name}
     fi
   else
     # Build unstable, and tag as "dev".

--- a/bin/load.sh
+++ b/bin/load.sh
@@ -5,6 +5,8 @@
 set -euo pipefail
 IDS=$'\n\t'
 
+source bin/common.sh
+
 for name in stackstorm; do
   # Load the tarball (tags are automatically loaded)
   ${dry_run} docker load -i tar/${name}.tar

--- a/bin/load.sh
+++ b/bin/load.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# This script runs within the CircleCI environment to build stackstorm images.
+
+set -euo pipefail
+IDS=$'\n\t'
+
+for name in stackstorm; do
+  # Load the tarball (tags are automatically loaded)
+  ${dry_run} docker load -i tar/${name}.tar
+done

--- a/bin/save.sh
+++ b/bin/save.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# This script runs within the CircleCI environment to build stackstorm images.
+
+set -euo pipefail
+IDS=$'\n\t'
+
+source bin/common.sh
+
+${dry_run} mkdir -p tar
+
+for name in stackstorm; do
+  if [ ! -z ${BUILD_DEV} ]; then
+    ${dry_run} docker save -o tar/${name}.tar stackstorm/${name}:dev
+
+    continue
+  fi
+
+  # From this point on, not a dev build...
+
+  st2_tag=${tag}
+
+  if [ -z ${CIRCLE_TAG} ]; then
+    # A tag was not pushed, so we only need to build 'latest' (not tagged)
+    tag='latest'
+  fi
+
+  name_tag="${name}:${tag}"
+
+  # Build the image, tag using CIRCLE_TAG
+  tags="stackstorm/${name_tag}"
+
+  if [ "v${tag}" == "${latest}" ]; then
+    tags+=" stackstorm/${name}:${short_tag:-}"
+  fi
+
+  if [ "$tag" != 'latest' ]; then
+    tags+=" stackstorm/${name}:latest"
+  fi
+
+  ${dry_run} docker save -o tar/${name}.tar ${tags}
+done


### PR DESCRIPTION
As noted in #112:

> The problem is that now the latest container does not contain these fixes

While the `stackstorm/stackstorm:latest` image has been updated recently, it appears the bits are old. This PR attempts to fix this issue, although I suspect it can only truly be tested in production.

I took this opportunity to refactor some code to simplify.