### PR TITLE
Need to add persistent volume for pack's config file

### DIFF
--- a/runtime/kubernetes-1ppc/init-st2.yml
+++ b/runtime/kubernetes-1ppc/init-st2.yml
@@ -22,7 +22,8 @@ spec:
         - >-
           mkdir /tmp/st2 &&
           mount -o bind /opt/stackstorm /tmp/st2 &&
-          rsync -avi /tmp/st2/packs/ /opt/stackstorm/packs/
+          rsync -avi /tmp/st2/packs/ /opt/stackstorm/packs/ &&
+          rsync -avi /tmp/st2/configs/ /opt/stackstorm/configs/
         envFrom:
         - configMapRef: { name: st2 }
         - configMapRef: { name: rabbitmq }
@@ -32,6 +33,8 @@ spec:
           mountPath: /opt/stackstorm/packs
         - name: st2-virtualenvs
           mountPath: /opt/stackstorm/virtualenvs
+        - name: st2-pack-configs
+          mountPath: /opt/stackstorm/configs
       volumes:
       - name: st2-packs
         persistentVolumeClaim:
@@ -39,6 +42,9 @@ spec:
       - name: st2-virtualenvs
         persistentVolumeClaim:
           claimName: st2-virtualenvs
+      - name: st2-pack-configs
+        persistentVolumeClaim:
+          claimName: st2-pack-configs
       restartPolicy: Never
 
 ---
@@ -67,6 +73,8 @@ spec:
           mountPath: /opt/stackstorm/packs
         - name: st2-virtualenvs
           mountPath: /opt/stackstorm/virtualenvs
+        - name: st2-pack-configs
+          mountPath: /opt/stackstorm/configs
       volumes:
       - name: st2-packs
         persistentVolumeClaim:
@@ -74,5 +82,8 @@ spec:
       - name: st2-virtualenvs
         persistentVolumeClaim:
           claimName: st2-virtualenvs
+      - name: st2-pack-configs
+        persistentVolumeClaim:
+          claimName: st2-pack-configs
       restartPolicy: Never
 

--- a/runtime/kubernetes-1ppc/st2.yml
+++ b/runtime/kubernetes-1ppc/st2.yml
@@ -147,6 +147,8 @@ spec:
           mountPath: /opt/stackstorm/packs
         - name: st2-virtualenvs
           mountPath: /opt/stackstorm/virtualenvs
+        - name: st2-pack-configs
+          mountPath: /opt/stackstorm/configs
       volumes:
       - name: st2-packs
         persistentVolumeClaim:
@@ -154,6 +156,9 @@ spec:
       - name: st2-virtualenvs
         persistentVolumeClaim:
           claimName: st2-virtualenvs
+      - name: st2-pack-configs
+        persistentVolumeClaim:
+          claimName: st2-pack-configs
 
 ---
 apiVersion: apps/v1beta1
@@ -209,6 +214,8 @@ spec:
           mountPath: /opt/stackstorm/packs
         - name: st2-virtualenvs
           mountPath: /opt/stackstorm/virtualenvs
+        - name: st2-pack-configs
+          mountPath: /opt/stackstorm/configs
       volumes:
       - name: st2-packs
         persistentVolumeClaim:
@@ -216,6 +223,9 @@ spec:
       - name: st2-virtualenvs
         persistentVolumeClaim:
           claimName: st2-virtualenvs
+      - name: st2-pack-configs
+        persistentVolumeClaim:
+          claimName: st2-pack-configs
 
 ---
 apiVersion: apps/v1beta1
@@ -416,6 +426,18 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: st2-virtualenvs
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Mi
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: st2-pack-configs
 spec:
   accessModes:
   - ReadWriteMany


### PR DESCRIPTION
There is a config parameter
https://github.com/StackStorm/st2/blob/master/st2common/st2common/bootstrap/configsregistrar.py#L104
it depends on 'system.base_path', this config option impact many places, so the pack's config file path is not a  independent config option, so the better way is add a persistent volume.
