### PR TITLE
Change nightly build from 5PM to 2AM Pacific Time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ workflows:
   nightly-workflow:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 9 * * *"
           filters:
             branches:
               only:


### PR DESCRIPTION
This better suits development in the pacific time zone.