### PR TITLE
Helm Chart

### DIFF
--- a/runtime/kubernetes-1ppc/helm/Chart.yaml
+++ b/runtime/kubernetes-1ppc/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for installing an instance of Stack Storm into a Kubernetes cluster
+name: stackstorm
+version: 0.1.0

--- a/runtime/kubernetes-1ppc/helm/README.md
+++ b/runtime/kubernetes-1ppc/helm/README.md
@@ -1,0 +1,26 @@
+## Stack Storm Helm Chart
+
+This chart is just a prototype!!!  Not for production use, yet!
+
+### Overview
+Install Stack Storm into Kubernetes cluster via Helm.  The chart leverages subcharts for mongodb, postgresql, rabbitmq, and redis.
+
+### Usage
+
+- Make sure your kubectl context is setup before proceeding, you should be able to run commands like `helm list`.  If not see https://docs.helm.sh/using_helm/ or #docker in stackstorm-community.slack.com
+
+0. `git clone git@github.com/stackstorm/st2-docker`
+0. `cd st2-docker`
+0. `git checkout helm_example_jbrownsm`
+0. `cd runtime/kubernetes-1ppc/helm`
+0. `helm install --name stackstorm-test1 --namespace stackstorm-test1 .`
+0. `kubectl --namespace stackstorm-test1 get pods`
+0. `sudo kubectl --namespace stackstorm-test1 port-forward $(kubectl --namespace stackstorm-test1 get pods -l app=st2web -o name | head -n1) 443:443` (Note nothing else can be on 443, at some point we'll put Nginx in front of this and not make it be port 443...)
+0. Goto https://localhost
+
+### Advanced Configuration
+
+- Adding an external-dns hostname
+- Exposing Stack Storm via an internal, cloud specific, Load Balancer
+- Exposing Stack Storm to the scary public internet
+- Adding secrets to your Stack Storm installation

--- a/runtime/kubernetes-1ppc/helm/requirements.lock
+++ b/runtime/kubernetes-1ppc/helm/requirements.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: mongodb
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 2.0.2
+- name: postgresql
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 0.10.0
+- name: rabbitmq
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 0.7.6
+- name: redis
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 3.0.2
+digest: sha256:5c9d95bd49f9f6ba0460125843d7e8a671779ab51d247691b43ccf8257e0ae80
+generated: 2018-04-23T21:58:15.432054-07:00

--- a/runtime/kubernetes-1ppc/helm/requirements.yaml
+++ b/runtime/kubernetes-1ppc/helm/requirements.yaml
@@ -1,0 +1,16 @@
+dependencies:
+  - name: mongodb
+    version: "2.0.2"
+    repository: "@stable"
+
+  - name: postgresql
+    version: "0.10.0"
+    repository: "@stable"
+
+  - name: rabbitmq
+    version: "0.7.6"
+    repository: "@stable"
+
+  - name: redis
+    version: "3.0.2"
+    repository: "@stable"

--- a/runtime/kubernetes-1ppc/helm/templates/_helpers.tpl
+++ b/runtime/kubernetes-1ppc/helm/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "..name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "..fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "..chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/runtime/kubernetes-1ppc/helm/templates/mistral-api-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/mistral-api-deployment.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-mistral-api
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: mistral-api
+    spec:
+      containers:
+      - name: mistral-api
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: mistral-api
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }
+        ports:
+        - containerPort: 8989

--- a/runtime/kubernetes-1ppc/helm/templates/mistral-api-service.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/mistral-api-service.yaml
@@ -1,0 +1,11 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "..fullname" . }}-mistral-api
+spec:
+  selector:
+    app: mistral-api
+  ports:
+  - protocol: TCP
+    port: 8989

--- a/runtime/kubernetes-1ppc/helm/templates/mistral-server-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/mistral-server-deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-mistral-server
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: mistral-server
+    spec:
+      containers:
+      - name: mistral-server
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: mistral-server
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }

--- a/runtime/kubernetes-1ppc/helm/templates/st2-configmap.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2-configmap.yaml
@@ -1,0 +1,28 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "..fullname" . }}-st2
+data:
+  ST2_USER: {{ .Values.stackstorm.user }}
+  ST2_PASSWORD: {{ .Values.stackstorm.password }}
+  ST2_AUTH_URL: http://{{ template "..fullname" . }}-st2auth:9100/
+  ST2_API_URL: http://{{ template "..fullname" . }}-st2api:9101/
+  ST2_STREAM_URL: http://{{ template "..fullname" . }}-st2stream:9102/
+  ST2_MISTRAL_API_URL: http://{{ template "..fullname" . }}-mistral-api:8989/v2
+  MONGO_USER: {{ .Values.mongodb.mongodbUsername }}
+  MONGO_PASS: {{ .Values.mongodb.mongodbPassword }}
+  MONGO_HOST: {{ template "..fullname" . }}-mongodb
+  MONGO_PORT: "27017"
+  RABBITMQ_DEFAULT_USER: {{ .Values.rabbitmq.rabbitmq.username }}
+  RABBITMQ_DEFAULT_PASS: {{ .Values.rabbitmq.rabbitmq.password }}
+  RABBITMQ_HOST: {{ template "..fullname" . }}-rabbitmq
+  RABBITMQ_PORT: "5672"
+  POSTGRES_DB: {{ .Values.postgresql.postgresDatabase }}
+  POSTGRES_USER: {{ .Values.postgresql.postgresUser }}
+  POSTGRES_PASSWORD: {{ .Values.postgresql.postgresPassword }}
+  POSTGRES_HOST: {{ template "..fullname" . }}-postgresql
+  POSTGRES_PORT: "5432"
+  REDIS_PASSWORD: {{ .Values.redis.password }}
+  REDIS_HOST: {{ template "..fullname" . }}-redis-master
+  REDIS_PORT: "6379"

--- a/runtime/kubernetes-1ppc/helm/templates/st2-register-content-job.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2-register-content-job.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "..fullname" . }}-st2-register-content-job
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": "post-install,post-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+spec:
+  template:
+    metadata:
+      name: {{ template "..fullname" . }}-st2-register-content-job
+    spec:
+      containers:
+      - name: register-content-job
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: IfNotPresent
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }
+        env:
+        - name: ST2_SERVICE
+          value: st2-register-content
+      restartPolicy: Never

--- a/runtime/kubernetes-1ppc/helm/templates/st2actionrunner-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2actionrunner-deployment.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2actionrunner
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2actionrunner
+    spec:
+      containers:
+      - name: st2actionrunner
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2actionrunner
+        - name: ST2_ACTION_AUTH_URL
+          value: http://{{ template "..fullname" . }}-st2auth:9100/
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }
+        {{- if .Values.stackstorm.volumeDef.volumeMounts }}
+        volumeMounts:
+{{ .Values.stackstorm.volumeDef.volumeMounts | toYaml | indent 10 }}
+        {{ end }}
+      {{- if .Values.stackstorm.volumeDef.volumes }}
+      volumes: 
+{{ .Values.stackstorm.volumeDef.volumes | toYaml | indent 8 }}
+      {{ end }}

--- a/runtime/kubernetes-1ppc/helm/templates/st2api-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2api-deployment.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2api
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2api
+    spec:
+      containers:
+      - name: st2api
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2api
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }
+        ports:
+        - containerPort: 9101

--- a/runtime/kubernetes-1ppc/helm/templates/st2api-service.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2api-service.yaml
@@ -1,0 +1,11 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "..fullname" . }}-st2api
+spec:
+  selector:
+    app: st2api
+  ports:
+  - protocol: TCP
+    port: 9101

--- a/runtime/kubernetes-1ppc/helm/templates/st2auth-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2auth-deployment.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2auth
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2auth
+    spec:
+      containers:
+      - name: st2auth
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2auth
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }
+        ports:
+        - containerPort: 9100

--- a/runtime/kubernetes-1ppc/helm/templates/st2auth-service.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2auth-service.yaml
@@ -1,0 +1,11 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "..fullname" . }}-st2auth
+spec:
+  selector:
+    app: st2auth
+  ports:
+  - protocol: TCP
+    port: 9100

--- a/runtime/kubernetes-1ppc/helm/templates/st2garbagecollector-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2garbagecollector-deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2garbagecollector
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2garbagecollector
+    spec:
+      containers:
+      - name: st2garbagecollector
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2garbagecollector
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }

--- a/runtime/kubernetes-1ppc/helm/templates/st2notifier-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2notifier-deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2notifier
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2notifier
+    spec:
+      containers:
+      - name: st2notifier
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2notifier
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }

--- a/runtime/kubernetes-1ppc/helm/templates/st2resultstracker-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2resultstracker-deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2resultstracker
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2resultstracker
+    spec:
+      containers:
+      - name: st2resultstracker
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2resultstracker
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }

--- a/runtime/kubernetes-1ppc/helm/templates/st2rulesengine-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2rulesengine-deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2rulesengine
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2rulesengine
+    spec:
+      containers:
+      - name: st2rulesengine
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2rulesengine
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }

--- a/runtime/kubernetes-1ppc/helm/templates/st2sensorcontainer-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2sensorcontainer-deployment.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2sensorcontainer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2sensorcontainer
+    spec:
+      containers:
+      - name: st2sensorcontainer
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2sensorcontainer
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }

--- a/runtime/kubernetes-1ppc/helm/templates/st2stream-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2stream-deployment.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2stream
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2stream
+    spec:
+      containers:
+      - name: st2stream
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2stream
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }
+        ports:
+        - containerPort: 9102

--- a/runtime/kubernetes-1ppc/helm/templates/st2stream-service.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2stream-service.yaml
@@ -1,0 +1,11 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "..fullname" . }}-st2stream
+spec:
+  selector:
+    app: st2stream
+  ports:
+  - protocol: TCP
+    port: 9102

--- a/runtime/kubernetes-1ppc/helm/templates/st2web-deployment.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2web-deployment.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "..fullname" . }}-st2web
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/st2-configmap.yaml") . | sha256sum }}
+      labels:
+        app: st2web
+    spec:
+      containers:
+      - name: st2web
+        image: {{ .Values.stackstorm.image.repository }}:{{ .Values.stackstorm.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: ST2_SERVICE
+          value: st2web
+        envFrom:
+        - configMapRef: { name: {{ template "..fullname" . }}-st2 }
+        ports:
+        - containerPort: 443
+      - name: dns-resolver
+        image: janeczku/go-dnsmasq:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: DNSMASQ_ENABLE_SEARCH
+          value: "1"
+        ports:
+        - containerPort: 53
+          protocol: UDP

--- a/runtime/kubernetes-1ppc/helm/templates/st2web-service.yaml
+++ b/runtime/kubernetes-1ppc/helm/templates/st2web-service.yaml
@@ -1,0 +1,23 @@
+{{ if .Values.stackstorm.createPublicLoadBalancer }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "..fullname" . }}-st2web
+  annotations:
+      {{ if .Values.stackstorm.internalLoadBalancer }}
+      cloud.google.com/load-balancer-type: "Internal"
+      service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+      service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+      {{ end }}
+      {{ if .Values.externalDNSHostname }}
+      external-dns.alpha.kubernetes.io/hostname: {{ .Values.externalDNSHostname }}
+      {{ end }}
+spec:
+  selector:
+    app: st2web
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    port: 443
+{{ end }}

--- a/runtime/kubernetes-1ppc/helm/values.yaml
+++ b/runtime/kubernetes-1ppc/helm/values.yaml
@@ -1,0 +1,53 @@
+stackstorm:
+  image:
+    repository: "stackstorm/stackstorm"
+    tag: "latest"
+  user: "stackstorm"
+  password: "stanley"
+
+  # Create a Load Balancer for accessing the st2web service
+  createLoadBalancer: false
+  # Make the Load Balancer internal?  If set to false, StackStorm will be avaiable from anywhere.
+  internalLoadBalancer: true
+  #externalDNSHostname: "stackstorm.custom-domain-managed-by-external-dns.com."
+
+  # Use this to mount volumes into the st2 containers.  This should mainly be used for mounting
+  # secrets into containers that do things.  I.E. st2actionrunner needs ssh keys or disk-based credentials
+  # for accessing something protected.
+  #
+  # Also, volumeMounts + volumes generally travel together, so I figured I'd do this for "simplicity"
+  volumeDef: {}
+  # volumeDef:
+  #   volumeMounts: []
+  #   volumes: []
+
+
+## MongoDB (Bitnami container)
+mongodb:
+  image:
+    tag: 3.6.4
+  mongodbUsername: "st2"
+  mongodbPassword: "stanley"
+  mongodbDatabase: "st2"
+
+##
+## RabbitMQ subchart overrides
+## https://github.com/kubernetes/charts/tree/master/stable/rabbitmq#configuration
+## All configuration for the RabbitMQ subchart is namespaced under rabbitmq per Helm's
+## subchart configuration strategy.
+##
+rabbitmq:
+  rabbitmq:
+    username: "st2"
+    password: "stanley"
+    erlangCookie: "rabbitmq"
+  rbacEnabled: true
+
+redis:
+  password: "stanley"
+
+postgresql:
+  imageTag: "9.6.2"
+  postgresDatabase: "mistral"
+  postgresUser: "mistral"
+  postgresPassword: "stanley"


### PR DESCRIPTION
Implemented
- [x] helm - helm install provisions working Stack Storm installation
- [x] values.yaml - supports custom images for Stack Storm, Postgres, Mongodb, RabbitMQ, and Redis
- [x] values.yaml - Enable Load Balancer in front of st2web service
- [x] values.yaml - Allow st2web service Load Balancer to be "Internal"

Not Implemented
- [ ] values.yaml - supports increasing default volume sizes for Postgres, Mongo, RabbitMQ and Redis
- [ ] values.yaml - supports HA Stack Storm design
- [ ] NOTES.txt - outlines how to interact with a working Stack Storm installation
- [ ] helm hook - register packs baked in image on helm install + upgrade
- [ ] custom - register content will redeploy existing packs, thus any rule based definition that is enabled will be disabled if the pack definition says enabled: false.  That may not be desired and currently is being handled by a custom script that enables rules based on conditional ST2_PROD environment variables.
- [ ] custom - How to manage `/opt/stackstorm/configs` yaml files?

Punt (Not going to happen in initial revision)
- Mongo Replica Set

Notes:
- This is based on the "bake your own container" approach