### PR TITLE
Fix/deploy logic

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -23,29 +23,12 @@ for name in stackstorm; do
 
   # From this point on, not a dev build...
 
-  st2_tag=${tag}
-
-  if [ -z ${CIRCLE_TAG} ]; then
-    # A tag was not pushed, so we only need to build 'latest' (not tagged)
-    tag='latest'
-  fi
-
   name_tag="${name}:${tag}"
 
-  # Build the image, tag using CIRCLE_TAG
+  # Build the ${name_tag} image using Dockerfile in images/${name}
   ${dry_run} docker build --build-arg ST2_TAG=${st2_tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
     --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
     --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
     --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \
     -t stackstorm/${name_tag} images/${name}
-
-  if [ "v${tag}" == "${latest}" ]; then
-    ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag}
-  else
-    echo "INFO: Short tag is unchanged since this is not a tagged build."
-  fi
-
-  if [ "$tag" != 'latest' ]; then
-    ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:latest
-  fi
 done

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -3,6 +3,7 @@
 #  latest       - the highest version tagged in the repo (beginning with "v")
 #  st2_tag      - the MAJOR.MINOR.PATCH version of st2 installed in the image
 #  short_tag    - MAJOR.MINOR from ${st2_tag}
+#  latest_short - contains the highest version beginning with ${short_tag}
 #  tagged_build - true if build was tagged, else false
 #  tag          - tag image with this value (if tagged_build st2_tag else latest)
 

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -44,7 +44,7 @@ if [ ! -z ${CIRCLE_TAG} ]; then
     CIRCLE_TAG_MINOR=${BASH_REMATCH[2]}
     CIRCLE_TAG_PATCH=${BASH_REMATCH[3]}
   else
-    echo "ERROR: CIRCLE_TAG must have format 'vMAJOR.MINOR.PATCH'"
+    echo "ERROR: CIRCLE_TAG must begin with format 'vMAJOR.MINOR.PATCH'"
     exit 1
   fi
 fi

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -34,12 +34,12 @@ echo CIRCLE_TAG=${CIRCLE_TAG}
 BUILD_DEV=${BUILD_DEV:-}
 echo BUILD_DEV=${BUILD_DEV}
 
-# Get the greatest tag prefixed with 'v'
+# Get the highest tag prefixed with 'v'
 # NOTE: We remove the 'v' prefix before returning
 latest=`git tag -l "v*" | sort -r | head -1 | cut -c 2-`
 
 if [ ! -z ${CIRCLE_TAG} ]; then
-  if [[ ${CIRCLE_TAG} =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  if [[ ${CIRCLE_TAG} =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+).*$ ]]; then
     CIRCLE_TAG_MAJOR=${BASH_REMATCH[1]}
     CIRCLE_TAG_MINOR=${BASH_REMATCH[2]}
     CIRCLE_TAG_PATCH=${BASH_REMATCH[3]}
@@ -53,7 +53,7 @@ short_tag=''
 
 if [[ ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
   # A tag was pushed, so we'll build an image using this specific release.
-  tagged_build=1
+  tagged_build=true
   st2_tag=${BASH_REMATCH[1]}
   tag=${st2_tag}
   short_tag="${CIRCLE_TAG_MAJOR}.${CIRCLE_TAG_MINOR}"
@@ -61,20 +61,10 @@ if [[ ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
   echo latest_short=${latest_short}
 else
   # NOTE: A valid version tag was not pushed
-  # Build and tag an image using the latest StackStorm release
-  tagged_build=0
+  # Build and tag an image using the highest StackStorm release
+  tagged_build=false
   tag='latest'
-
-  if [[ ${latest} =~ ^v(.+)$ ]]; then
-    st2_tag=${BASH_REMATCH[1]}
-  else
-    echo "ERROR: Could not find a git tag in the st2-docker repo with format vX.Y.Z"
-    echo "To resolve, run:"
-    echo "  $ git co master"
-    echo "  $ git tag -a 'vX.Y.Z' -m 'Stamping X.Y.Z' HEAD"
-    echo "  $ git push --tags"
-    exit 1
-  fi
+  st2_tag=${latest}
 fi
 
 # These variables are available in calling scripts

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -1,4 +1,10 @@
-# The following code snippet is used by build.sh and deploy.sh
+# The following variables will be set for use by the calling script
+
+#  latest       - the highest version tagged in the repo (beginning with "v")
+#  st2_tag      - the MAJOR.MINOR.PATCH version of st2 installed in the image
+#  short_tag    - MAJOR.MINOR from ${st2_tag}
+#  tagged_build - true if build was tagged, else false
+#  tag          - tag image with this value (if tagged_build st2_tag else latest)
 
 # Set debug to 'echo' to test
 dry_run=''
@@ -28,13 +34,17 @@ if [ -z ${CIRCLE_SHA1} ]; then
   exit 1
 fi
 
-# Get the latest tag beginning with 'v'
-latest=`git tag -l "v*" | sort -r | head -1`
-echo latest=${latest}
+# Get the greatest tag prefixed with 'v'
+# NOTE: We remove the 'v' prefix before returning
+latest=`git tag -l "v*" | sort -r | head -1 | cut -c 2-`
 
 if [ ! -z ${CIRCLE_TAG} ]; then
-  if [[ ! ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
-    echo "ERROR: CIRCLE_TAG must begin with 'v'"
+  if [[ ${CIRCLE_TAG} =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    CIRCLE_TAG_MAJOR=${BASH_REMATCH[1]}
+    CIRCLE_TAG_MINOR=${BASH_REMATCH[2]}
+    CIRCLE_TAG_PATCH=${BASH_REMATCH[3]}
+  else
+    echo "ERROR: CIRCLE_TAG must have format 'vMAJOR.MINOR.PATCH'"
     exit 1
   fi
 fi
@@ -43,14 +53,20 @@ short_tag=''
 
 if [[ ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
   # A tag was pushed, so we'll build an image using this specific release.
-  tag=${BASH_REMATCH[1]}
-  if [[ ${CIRCLE_TAG} =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    short_tag="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
-  fi
+  tagged_build=1
+  st2_tag=${BASH_REMATCH[1]}
+  tag=${st2_tag}
+  short_tag="${CIRCLE_TAG_MAJOR}.${CIRCLE_TAG_MINOR}"
+  latest_short=`git tag -l "v${short_tag}*" | sort -r | head -1 | cut -c 2-`
+  echo latest_short=${latest_short}
 else
+  # NOTE: A valid version tag was not pushed
   # Build and tag an image using the latest StackStorm release
+  tagged_build=0
+  tag='latest'
+
   if [[ ${latest} =~ ^v(.+)$ ]]; then
-    tag=${BASH_REMATCH[1]}
+    st2_tag=${BASH_REMATCH[1]}
   else
     echo "ERROR: Could not find a git tag in the st2-docker repo with format vX.Y.Z"
     echo "To resolve, run:"
@@ -61,4 +77,9 @@ else
   fi
 fi
 
+# These variables are available in calling scripts
+echo latest=${latest}
+echo short_tag=${short_tag}
+echo st2_tag=${st2_tag}
 echo tag=${tag}
+echo tagged_build=${tagged_build}

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -20,12 +20,6 @@ echo WORKSPACE=${WORKSPACE}
 CIRCLE_SHA1=${CIRCLE_SHA1:-}
 echo CIRCLE_SHA1=${CIRCLE_SHA1}
 
-CIRCLE_TAG=${CIRCLE_TAG:-}
-echo CIRCLE_TAG=${CIRCLE_TAG}
-
-BUILD_DEV=${BUILD_DEV:-}
-echo BUILD_DEV=${BUILD_DEV}
-
 if [ -z ${CIRCLE_SHA1} ]; then
   echo "ERROR: CIRCLE_SHA1 is not defined."
   echo "To resolve, run:"
@@ -33,6 +27,12 @@ if [ -z ${CIRCLE_SHA1} ]; then
   echo "  $ $0"
   exit 1
 fi
+
+CIRCLE_TAG=${CIRCLE_TAG:-}
+echo CIRCLE_TAG=${CIRCLE_TAG}
+
+BUILD_DEV=${BUILD_DEV:-}
+echo BUILD_DEV=${BUILD_DEV}
 
 # Get the greatest tag prefixed with 'v'
 # NOTE: We remove the 'v' prefix before returning

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -21,9 +21,9 @@ for name in stackstorm; do
   # From this point on, not a dev build...
   name_tag="${name}:${tag}"
 
-  if [ ${tagged_build} ]; then
+  if ${tagged_build}; then
     # gatekeeper.sh returns 'allow' on STDOUT if the images can be pushed
-    if [ `bin/gatekeeper.sh ${tag}` != 'allow' ]; then
+    if [ `bin/gatekeeper.sh ${name} ${tag}` != 'allow' ]; then
       echo "${name_tag} already exists on docker hub.. not pushing again!"
       exit 1
     fi
@@ -31,7 +31,7 @@ for name in stackstorm; do
 
   ${dry_run} docker push stackstorm/${name}:${tag}
 
-  if [ ${tagged_build} ]; then
+  if ${tagged_build}; then
     if [ "${st2_tag}" == "${latest_short}" ]; then
       ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag}
       ${dry_run} docker push stackstorm/${name}:${short_tag}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -19,21 +19,29 @@ for name in stackstorm; do
   fi
 
   # From this point on, not a dev build...
+  name_tag="${name}:${tag}"
 
-  # Push the tag to docker hub if and only if this is a tagged build.
-  # ASSUMPTION: Builds are never "re-tagged".
-  if [ ! -z ${CIRCLE_TAG} ]; then
-    if [ "${CIRCLE_TAG}" == "${latest}" ]; then
-      # Update latest if and only if the tag is the most recent tag.
-      # ASSUMPTION: Tags are applied in monotonically increasing order.
-      ${dry_run} docker push stackstorm/${name}:${tag}
-      if [ ! -z "${short_tag}" ]; then
-        ${dry_run} docker push stackstorm/${name}:${short_tag}
-      fi
-    else
-      echo "Not deploying image. ${CIRCLE_TAG} != ${latest}"
+  if [ ${tagged_build} ]; then
+    # gatekeeper returns 'allow' if the images can be pushed
+    gatekeeper=`bin/gatekeeper.sh ${tag}`
+
+    if [ ${gatekeeper} != 'allow' ]; then
+      echo "${name_tag} already exists on docker hub.. not pushing again!"
+      exit 1
     fi
-  else
-    ${dry_run} docker push stackstorm/${name}:latest
+  fi
+
+  ${dry_run} docker push stackstorm/${name}:${tag}
+
+  if [ ${tagged_build} ]; then
+    if [ "${st2_tag}" == "${latest_short}" ]; then
+      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:${short_tag}
+      ${dry_run} docker push stackstorm/${name}:${short_tag}
+    fi
+
+    if [ "${st2_tag}" == "${latest}" ]; then
+      ${dry_run} docker tag stackstorm/${name_tag} stackstorm/${name}:latest
+      ${dry_run} docker push stackstorm/${name}:latest
+    fi
   fi
 done

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -22,10 +22,8 @@ for name in stackstorm; do
   name_tag="${name}:${tag}"
 
   if [ ${tagged_build} ]; then
-    # gatekeeper returns 'allow' if the images can be pushed
-    gatekeeper=`bin/gatekeeper.sh ${tag}`
-
-    if [ ${gatekeeper} != 'allow' ]; then
+    # gatekeeper.sh returns 'allow' on STDOUT if the images can be pushed
+    if [ `bin/gatekeeper.sh ${tag}` != 'allow' ]; then
       echo "${name_tag} already exists on docker hub.. not pushing again!"
       exit 1
     fi

--- a/bin/gatekeeper.sh
+++ b/bin/gatekeeper.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+IDS=$'\n\t'
+
+tag=$1
+
+if [ ${tag} == 'latest' ]; then
+  echo 'allow'
+  exit 0
+fi
+
+wget -q https://registry.hub.docker.com/v1/repositories/stackstorm/${name}/tags -O - \
+  | sed -e 's/[][]//g' -e 's/"//g' -e 's/ //g' | tr '}' '\n'  | awk -F: '{print $3}' | grep ${tag} \
+ || echo 'allow'

--- a/bin/gatekeeper.sh
+++ b/bin/gatekeeper.sh
@@ -3,7 +3,13 @@
 set -euo pipefail
 IDS=$'\n\t'
 
-tag=$1
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <name> <tag>"
+  exit 1
+fi
+
+name=$1
+tag=$2
 
 if [ ${tag} == 'latest' ]; then
   echo 'allow'

--- a/bin/save.sh
+++ b/bin/save.sh
@@ -18,25 +18,10 @@ for name in stackstorm; do
 
   # From this point on, not a dev build...
 
-  st2_tag=${tag}
-
-  if [ -z ${CIRCLE_TAG} ]; then
-    # A tag was not pushed, so we only need to build 'latest' (not tagged)
-    tag='latest'
-  fi
-
   name_tag="${name}:${tag}"
 
-  # Build the image, tag using CIRCLE_TAG
+  # Save the image ${name} using tag ${tag}
   tags="stackstorm/${name_tag}"
-
-  if [ "v${tag}" == "${latest}" ]; then
-    tags+=" stackstorm/${name}:${short_tag:-}"
-  fi
-
-  if [ "$tag" != 'latest' ]; then
-    tags+=" stackstorm/${name}:latest"
-  fi
 
   ${dry_run} docker save -o ${WORKSPACE}/${name}.tar ${tags}
 done


### PR DESCRIPTION
Preemptively fixed an issue with `st2-docker` deploy logic. Glad I finally had a chance to fix.. it's been bugging me for a while.

The prior assumption was that st2 versions increased monotonically. This assumption is no longer valid with `2.6.1` being released after `2.7.2`.

A few other changes:

 - Added `${latest_short}` variable which contains the highest version beginning with `${short_tag}`
 - Added a gatekeeper which ensures that 'immutable' images are not re-pushed to docker hub.
 - Improved comments and variable names.