### PR TITLE
this commit fixes #135

### DIFF
--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -117,7 +117,7 @@ RUN mkdir -p /home/stanley/.ssh && chmod 0700 /home/stanley/.ssh \
 RUN wget -O - http://nginx.org/keys/nginx_signing.key | apt-key add - \
     && echo "deb http://nginx.org/packages/mainline/ubuntu/ trusty nginx" >> /etc/apt/sources.list \
     && echo "deb-src http://nginx.org/packages/mainline/ubuntu/ trusty nginx" >> /etc/apt/sources.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ABF5BD827BD9BF62 \
+    && apt-key adv --keyserver hkg://keyserver.ubuntu.com:80 --recv-keys ABF5BD827BD9BF62 \
     && apt-get update \
     && apt-get install -y nginx \
     && cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/st2-base.cnf \


### PR DESCRIPTION
Have found that the default port for apt-key is filtered by some corporate firewalls. Possible solution is to replace `&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ABF5BD827BD9BF62 \` with `&& apt-key adv --keyserver hkg://keyserver.ubuntu.com:80 --recv-keys ABF5BD827BD9BF62 \` allowing the traffic to utilize more commonly used ports.