### PR TITLE
Generate secrets when container is started

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ packs
 packs.dev
 *.pyc
 conf
+ssh
+ssl

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2018-06-26
+----------
+
+Changed
+~~~~~~~
+
+* The image no longer contains ssh and ssl secrets. You must now provide them at runtime.
+
 2018-02-27
 ----------
 

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,17 @@ SHA := $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty=*)
 build:
 	docker build --build-arg CIRCLE_SHA1="$(SHA)" -t stackstorm/stackstorm:latest images/stackstorm
 
+build-dev:
+	docker build --build-arg ST2_REPO=unstable --build-arg CIRCLE_SHA1="$(SHA)" -t stackstorm/stackstorm:local-dev images/stackstorm
+
 env:
 	bin/write-env.sh conf
+
+gen-ssh:
+	bin/gen-ssh.sh
+
+gen-ssl:
+	bin/gen-ssl.sh
 
 up:
 	docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@
 git clone git@github.com:stackstorm/st2-docker
 cd st2-docker
 make env
+make gen-ssh
+make gen-ssl
 docker-compose up -d
 docker-compose exec stackstorm bash
 ```
+
+Please see the section below regarding SSH key and SSL certificates.
 
 Open `https://localhost` in your browser. StackStorm Username/Password can be found in: `cat conf/stackstorm.env`
 
@@ -49,6 +53,12 @@ The default container configuration is as follows:
  - postgres
  - redis
 
+### SSH Keys and SSL Certificates
+
+If you do not already have ssh key and ssl certificates, you can generate them using `make gen-ssh`
+and `make gen-ssl`. By default, the secrets are found in the default `ssh` and `ssl` directories at the top
+of the `st2-docker` workspace. If you already have ssh keys and ssl certificates, define the `ST2_SSH_DIR` and
+`ST2_SSL_DIR` environment variables respectively. The secrets will be available in the stackstorm container.
 
 ### Step by step instructions
 
@@ -70,6 +80,22 @@ NOTE: `make env` only needs to be run once.
 As an example, if you want to change the username and password used by StackStorm, change the
 `ST2_USER` and `ST2_PASSWORD` variables in `conf/stackstorm.env` prior to bringing up your docker
 environment.
+
+  ```
+  make gen-ssh
+  ```
+
+NOTE: `make gen-ssh` only needs to be run once.
+
+This generates the ssh key and `authorized_keys` file available in the container at `~stanley/.ssh`.
+
+  ```
+  make gen-ssl
+  ```
+
+NOTE: `make gen-ssl` only needs to be run once.
+
+This generates the `st2.key` and `st2.crt` files required by nginx (st2web).
 
 Second, start the docker environment. execute
 

--- a/bin/gen-certs.sh
+++ b/bin/gen-certs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SSL_DIR=ssl
+
+ST2_KEY=${SSL_DIR}/st2.key
+ST2_CRT=${SSL_DIR}/st2.crt
+
+mkdir -p ${SSL_DIR}
+openssl req -x509 -newkey rsa:2048 -keyout ${ST2_KEY} -out ${ST2_CRT} -days 3650 -nodes -subj '/O=st2 self signed/CN=localhost'

--- a/bin/gen-ssh.sh
+++ b/bin/gen-ssh.sh
@@ -2,15 +2,13 @@
 
 set -euo pipefail
 
-SSH_DIR=/home/stanley/.ssh
+SSH_DIR=ssh
 AUTHORIZED_KEYS=${SSH_DIR}/authorized_keys
 
 SSH_PRIV_KEY=${SSH_DIR}/stanley_rsa
 SSH_PUB_KEY=${SSH_PRIV_KEY}.pub
 
-SSL_DIR=/etc/ssl/st2
-ST2_KEY=${SSL_DIR}/st2.key
-ST2_CRT=${SSL_DIR}/st2.crt
+mkdir -p ${SSH_DIR}
 
 if [ ! -f ${SSH_PRIV_KEY} ]; then
   ssh-keygen -f ${SSH_PRIV_KEY} -P ""
@@ -18,8 +16,4 @@ fi
 
 if ! grep -s -q -f ${SSH_PUB_KEY} ${AUTHORIZED_KEYS}; then
   cat ${SSH_PUB_KEY} >> ${AUTHORIZED_KEYS}
-fi
-
-if [ ! -f ${ST2_KEY} ]; then
-  openssl req -x509 -newkey rsa:2048 -keyout ${ST2_KEY} -out ${ST2_CRT} -days 3650 -nodes -subj '/O=st2 self signed/CN=localhost'
 fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - ./runtime/entrypoint.d:/st2-docker/entrypoint.d
       - ./runtime/st2.d:/st2-docker/st2.d
       - ./conf/stackstorm.env:/st2-docker/env
+      - ${ST2_SSH_DIR:-./ssh}:/home/stanley/.ssh
+      - ${ST2_SSL_DIR:-./ssl}:/etc/ssl/st2
     dns_search: .
 
 ### External Services

--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -136,6 +136,9 @@ COPY bin/entrypoint-1ppc.sh /st2-docker/bin/entrypoint-1ppc.sh
 COPY bin/inject_env.py /st2-docker/bin/inject_env.py
 COPY config/nginx.st2-1ppc.conf.tpl /etc/nginx/conf.d/st2-1ppc.conf.tpl
 
+VOLUME ["/home/stanley/.ssh"]
+VOLUME ["/etc/ssl/st2"]
+
 # Default username/password is used unless overridden by supplying ST2_USER and/or ST2_PASSWORD
 # environment variables to `docker run` after the name of the image:
 #   docker run -e ST2_USER... image

--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -106,8 +106,6 @@ RUN bash -c 'source /opt/stackstorm/st2/bin/activate && pip install redis'
 
 # Setup SSH and SUDO access for stanley user
 RUN mkdir -p /home/stanley/.ssh && chmod 0700 /home/stanley/.ssh \
-    && ssh-keygen -f /home/stanley/.ssh/stanley_rsa -P "" \
-    && cat /home/stanley/.ssh/stanley_rsa.pub >> /home/stanley/.ssh/authorized_keys \
     && chown -R stanley:stanley /home/stanley/.ssh \
     && echo "stanley    ALL=(ALL)       NOPASSWD: SETENV: ALL" >> /etc/sudoers.d/st2 \
     && chmod 0440 /etc/sudoers.d/st2 \
@@ -123,8 +121,7 @@ RUN wget -O - http://nginx.org/keys/nginx_signing.key | apt-key add - \
     && cp /usr/share/doc/st2/conf/nginx/st2.conf /etc/nginx/conf.d/st2-base.cnf \
     && ( cd /etc/nginx/conf.d && ln -s st2-base.cnf st2.conf ) \
     && mkdir -p /etc/ssl/st2 \
-    && mkdir /var/run/sshd \
-    && openssl req -x509 -newkey rsa:2048 -keyout /etc/ssl/st2/st2.key -out /etc/ssl/st2/st2.crt -days 3650 -nodes -subj '/O=st2 self signed/CN=localhost'
+    && mkdir /var/run/sshd
 
 EXPOSE 22 443
 

--- a/images/stackstorm/bin/entrypoint.sh
+++ b/images/stackstorm/bin/entrypoint.sh
@@ -64,7 +64,7 @@ for f in /st2-docker/entrypoint.d/*; do
 done
 
 # 1ppc: launch entrypoint-1ppc.sh via dumb-init if $ST2_SERVICE is set
-if [ ! -z ${ST2_SERVICE} ]; then
+if [ ! -z ${ST2_SERVICE:-} ]; then
   exec /dumb-init -- /st2-docker/bin/entrypoint-1ppc.sh
 fi
 

--- a/runtime/entrypoint.d/generate-secrets.sh
+++ b/runtime/entrypoint.d/generate-secrets.sh
@@ -1,18 +1,22 @@
 #!/bin/bash
+
+set -euo pipefail
+
 SSH_DIR=/home/stanley/.ssh
 AUTHORIZED_KEYS=${SSH_DIR}/authorized_keys
 
 SSH_PRIV_KEY=${SSH_DIR}/stanley_rsa
 SSH_PUB_KEY=${SSH_PRIV_KEY}.pub
 
-ST2_KEY=/etc/ssl/st2/st2.key
-ST2_CRT=/etc/ssl/st2/st2.crt
+SSL_DIR=/etc/ssl/st2
+ST2_KEY=${SSL_DIR}/st2.key
+ST2_CRT=${SSL_DIR}/st2.crt
 
 if [ ! -f ${SSH_PRIV_KEY} ]; then
   ssh-keygen -f ${SSH_PRIV_KEY} -P ""
 fi
 
-if [ ! -f ${AUTHORIZED_KEYS} ]; then
+if ! grep -s -q -f ${SSH_PUB_KEY} ${AUTHORIZED_KEYS}; then
   cat ${SSH_PUB_KEY} >> ${AUTHORIZED_KEYS}
 fi
 

--- a/runtime/entrypoint.d/generate-secrets.sh
+++ b/runtime/entrypoint.d/generate-secrets.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+SSH_DIR=/home/stanley/.ssh
+AUTHORIZED_KEYS=${SSH_DIR}/authorized_keys
+
+SSH_PRIV_KEY=${SSH_DIR}/stanley_rsa
+SSH_PUB_KEY=${SSH_PRIV_KEY}.pub
+
+ST2_KEY=/etc/ssl/st2/st2.key
+ST2_CRT=/etc/ssl/st2/st2.crt
+
+if [ ! -f ${SSH_PRIV_KEY} ]; then
+  ssh-keygen -f ${SSH_PRIV_KEY} -P ""
+fi
+
+if [ ! -f ${AUTHORIZED_KEYS} ]; then
+  cat ${SSH_PUB_KEY} >> ${AUTHORIZED_KEYS}
+fi
+
+if [ ! -f ${ST2_KEY} ]; then
+  openssl req -x509 -newkey rsa:2048 -keyout ${ST2_KEY} -out ${ST2_CRT} -days 3650 -nodes -subj '/O=st2 self signed/CN=localhost'
+fi


### PR DESCRIPTION
See https://github.com/StackStorm/packer-st2/issues/39.

Remaining tasks:

 - [ ] Remove the files containing secrets from the stackstorm-all image.
 - [ ] Create the files when the stackstorm-all image boots for the first time.