### PR TITLE
Update changelog with TAG -> ST2_IMAGE_TAG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2018-06-18
+----------
+
+Changed
+~~~~~~~
+
+* The TAG environment variable is replaced by ST2_IMAGE_TAG.
+
 2018-02-27
 ----------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 Changed
 ~~~~~~~
 
-* The TAG environment variable is replaced by ST2_IMAGE_TAG.
+* The ``TAG`` environment variable is replaced by ``ST2_IMAGE_TAG``.
 
 2018-02-27
 ----------

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ SHA := $(shell git describe --match=NeVeRmAtCh --always --abbrev=40 --dirty=*)
 build:
 	docker build --build-arg CIRCLE_SHA1="$(SHA)" -t stackstorm/stackstorm:latest images/stackstorm
 
+dev-build:
+	docker build --build-arg ST2_REPO=unstable --build-arg CIRCLE_SHA1="$(SHA)" -t stackstorm/stackstorm:local-dev images/stackstorm
+
 env:
 	bin/write-env.sh conf
 


### PR DESCRIPTION
This PR addresses the fact that https://github.com/StackStorm/st2-docker/pull/131 did not include the necessary entry in the CHANGELOG.