### PR TITLE
Add st2workflowengine to compose-1ppc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2018-06-28
+----------
+
+Changed
+~~~~~~~
+
+* Add ``st2workflowengine`` to ``entrypoint-1ppc.sh`` and ``compose-1ppc/docker-compose.yml``.
+
 2018-02-27
 ----------
 

--- a/images/stackstorm/bin/entrypoint-1ppc.sh
+++ b/images/stackstorm/bin/entrypoint-1ppc.sh
@@ -38,6 +38,10 @@ case "$ST2_SERVICE" in
     DAEMON_ARGS="--config-file /etc/st2/st2.conf"
     exec /opt/stackstorm/st2/bin/st2rulesengine ${DAEMON_ARGS}
     ;;
+  "st2workflowengine" )
+    DAEMON_ARGS="--config-file /etc/st2/st2.conf"
+    exec /opt/stackstorm/st2/bin/st2workflowengine ${DAEMON_ARGS}
+    ;;
   "st2actionrunner" )
     DAEMON_ARGS="--config-file /etc/st2/st2.conf"
     exec /opt/stackstorm/st2/bin/st2actionrunner ${DAEMON_ARGS}

--- a/runtime/compose-1ppc/docker-compose.yml
+++ b/runtime/compose-1ppc/docker-compose.yml
@@ -53,6 +53,10 @@ services:
     <<: *base
     environment:
       - ST2_SERVICE=st2resultstracker
+  st2workflowengine:
+    <<: *base
+    environment:
+      - ST2_SERVICE=st2workflowengine
   st2notifier:
     <<: *base
     environment:

--- a/runtime/kubernetes-1ppc/st2.yml
+++ b/runtime/kubernetes-1ppc/st2.yml
@@ -293,6 +293,30 @@ spec:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
+  name: st2workflowengine
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: st2workflowengine
+    spec:
+      containers:
+      - name: st2workflowengine
+        image: stackstorm/stackstorm:latest
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: ST2_SERVICE
+          value: st2workflowengine
+        envFrom:
+        - configMapRef: { name: st2 }
+        - configMapRef: { name: rabbitmq }
+        - configMapRef: { name: postgres }
+
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
   name: mistral-api
 spec:
   replicas: 1


### PR DESCRIPTION
Ensure that stackstorm, stackstorm-all and 1ppc (both compose and k8s) execute `st2workflowengine`, which was added to v2.8.0.

Add `st2workflowengine` to:

 - [x] `entrypoint-1ppc.sh`
 - [x] `runtime/compose-1ppc/docker-compose.yml`
 - [x] `runtime/kubernetes-1ppc/st2.yml`
 - [ ] ~~`stackstorm-all`~~
