### PR TITLE
Add proper service dependencies to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - conf/redis.env
     ports:
       - "443:443"
+    depends_on:
+      - mongo
+      - postgres
+      - rabbitmq
+      - redis
     networks:
       - public
       - private


### PR DESCRIPTION
Without dependencies, all services start and stop in parallel.  A normal startup should start mongo, postgres, rabbitmq, and redis before starting stackstorm.  A normal shutdown should stop stackstorm before them, so it has a chance to save its state.  Otherwise mongo might be ripped out from under it while it is still doing things.