### PR TITLE
1ppc: Add st2timersengine (new in v2.9)

### DIFF
--- a/images/stackstorm/bin/entrypoint-1ppc.sh
+++ b/images/stackstorm/bin/entrypoint-1ppc.sh
@@ -58,6 +58,10 @@ case "$ST2_SERVICE" in
     DAEMON_ARGS="--config-file /etc/st2/st2.conf"
     exec /opt/stackstorm/st2/bin/st2garbagecollector ${DAEMON_ARGS}
     ;;
+  "st2timersengine" )
+    DAEMON_ARGS="--config-file /etc/st2/st2.conf"
+    exec /opt/stackstorm/st2/bin/st2timersengine ${DAEMON_ARGS}
+    ;;   
   "mistral-api" )
     set -e
     /opt/stackstorm/mistral/bin/mistral-db-manage --config-file /etc/mistral/mistral.conf upgrade head

--- a/runtime/compose-1ppc/docker-compose.yml
+++ b/runtime/compose-1ppc/docker-compose.yml
@@ -65,6 +65,10 @@ services:
     <<: *base
     environment:
       - ST2_SERVICE=st2garbagecollector
+  st2timersengine:
+    <<: *base
+    environment:
+      - ST2_SERVICE=st2timersengine
   mistral-api:
     <<: *base
     environment:


### PR DESCRIPTION
Add support for st2timersengine in 1ppc which was added in v2.9