### PR TITLE
Update Dockerfile to install Node.js 10 for ST2 v3+ (default to Node.js 6)

### DIFF
--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -80,8 +80,16 @@ COPY bin/install.sh /install.sh
 RUN /install.sh --tag=${ST2_TAG} --st2=${ST2_VERSION} --st2web=${ST2WEB_VERSION} --st2mistral=${ST2MISTRAL_VERSION} --user=${CIRCLE_PROJECT_USERNAME} --repo=${CIRCLE_PROJECT_REPONAME} --buildurl=${CIRCLE_BUILD_URL} --sha=${CIRCLE_SHA1}
 
 # Install chatops and disable unless entrypoint.d file is present
-# Install st2-chatops with Node.js v6 requirement
-RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override
+# Install st2-chatops with Node.js v6/v10 requirement
+RUN if [ -n "${ST2_VERSION}" ]; then \
+        if [ $(printf "3.0\n${ST2_VERSION}\n" | sort -V | head -n 1) = "3.0" ]; then \
+            (curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override); \
+        else \
+            (curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override); \
+        fi; \
+    else \
+        (curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override); \
+    fi
 
 # Unless these lines are changed, the services are not started when runlevel -> 2
 # Call mistral-db-manage before mistral starts

--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -83,7 +83,7 @@ RUN /install.sh --tag=${ST2_TAG} --st2=${ST2_VERSION} --st2web=${ST2WEB_VERSION}
 # Install st2-chatops with Node.js v6/v10 requirement
 # This sorts (descending) a two-element list containing "3.0" and "${ST2_VERSION}",
 # using GNU sort's version comparison (-V).
-# If the "3.0" element is the first element, then $ST2_VERSION is greater than 3.0.
+# If the "3.0" element is the first element, then $ST2_VERSION >= 3.0.
 # If ST2_VERSION is >= 3.0, then install Node.js v10. Otherwise, install Node.js v6.
 RUN if [ -n "${ST2_VERSION}" ]; then \
         if [ $(printf "3.0\n${ST2_VERSION}\n" | sort -V | head -n 1) = "3.0" ]; then \

--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -81,6 +81,10 @@ RUN /install.sh --tag=${ST2_TAG} --st2=${ST2_VERSION} --st2web=${ST2WEB_VERSION}
 
 # Install chatops and disable unless entrypoint.d file is present
 # Install st2-chatops with Node.js v6/v10 requirement
+# This sorts (descending) a two-element list containing "3.0" and "${ST2_VERSION}",
+# using GNU sort's version comparison (-V).
+# If the "3.0" element is the first element, then $ST2_VERSION is greater than 3.0.
+# If ST2_VERSION is >= 3.0, then install Node.js v10. Otherwise, install Node.js v6.
 RUN if [ -n "${ST2_VERSION}" ]; then \
         if [ $(printf "3.0\n${ST2_VERSION}\n" | sort -V | head -n 1) = "3.0" ]; then \
             (curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override); \


### PR DESCRIPTION
Install Node.js v10 if `ST2_VERSION` sorts (by version) higher than 3.0.

This defaults to installing Node.js v6. I'm not 100% sure this is desired behavior.