### PR TITLE
Use a proper version sort

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 defaults: &defaults
   working_directory: /build
   docker:
-    - image: docker:17.06.0-ce-git
+    - image: docker:18.06.0-ce-git
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Install bash
-          command: apk add --no-cache bash
+          command: apk add --no-cache bash coreutils
       - run:
           name: Build image
           command: bin/build.sh
@@ -39,7 +39,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Install bash
-          command: apk add --no-cache bash
+          command: apk add --no-cache bash coreutils
       - run:
           name: Load image
           command: bin/load.sh
@@ -58,7 +58,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Install bash
-          command: apk add --no-cache bash
+          command: apk add --no-cache bash coreutils
       - run:
           name: Build image
           command: bin/build.sh
@@ -79,7 +79,7 @@ jobs:
           docker_layer_caching: true
       - run:
           name: Install bash
-          command: apk add --no-cache bash
+          command: apk add --no-cache bash coreutils
       - run:
           name: Load image from workspace
           command: bin/load.sh

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -12,7 +12,7 @@ for name in stackstorm; do
     # Triggered to run nightly via ops-infra
     # Build unstable, and tag as "dev".
 
-    ${dry_run} docker build --build-arg ST2_REPO=unstable --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
+    ${dry_run} docker build --no-cache --build-arg ST2_REPO=unstable --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
       --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
       --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
       --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \
@@ -26,7 +26,7 @@ for name in stackstorm; do
   name_tag="${name}:${tag}"
 
   # Build the ${name_tag} image using Dockerfile in images/${name}
-  ${dry_run} docker build --build-arg ST2_TAG=${st2_tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
+  ${dry_run} docker build --no-cache --build-arg ST2_TAG=${st2_tag} --build-arg CIRCLE_SHA1=${CIRCLE_SHA1} \
     --build-arg CIRCLE_PROJECT_USERNAME=${CIRCLE_PROJECT_USERNAME:-} \
     --build-arg CIRCLE_PROJECT_REPONAME=${CIRCLE_PROJECT_REPONAME:-} \
     --build-arg CIRCLE_BUILD_URL=${CIRCLE_BUILD_URL:-} \

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -37,7 +37,7 @@ echo BUILD_DEV=${BUILD_DEV}
 
 # Get the highest tag prefixed with 'v'
 # NOTE: We remove the 'v' prefix before returning
-latest=`git tag -l "v*" | sort -r | head -1 | cut -c 2-`
+latest=`git tag -l "v*" | sort -rV | head -1 | cut -c 2-`
 
 if [ ! -z ${CIRCLE_TAG} ]; then
   if [[ ${CIRCLE_TAG} =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+).*$ ]]; then
@@ -58,7 +58,7 @@ if [[ ${CIRCLE_TAG} =~ ^v(.+)$ ]]; then
   st2_tag=${BASH_REMATCH[1]}
   tag=${st2_tag}
   short_tag="${CIRCLE_TAG_MAJOR}.${CIRCLE_TAG_MINOR}"
-  latest_short=`git tag -l "v${short_tag}*" | sort -r | head -1 | cut -c 2-`
+  latest_short=`git tag -l "v${short_tag}*" | sort -rV | head -1 | cut -c 2-`
   echo latest_short=${latest_short}
 else
   # NOTE: A valid version tag was not pushed

--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -78,10 +78,7 @@ COPY bin/install.sh /install.sh
 
 # It is not possible to dynamically set ARG's, so we do the needful in bin/install.sh
 # Install st2, st2web, st2mistral and st2chatops
-RUN /install.sh --tag=${ST2_TAG} --st2=${ST2_VERSION} --st2web=${ST2WEB_VERSION} \
-    --st2mistral=${ST2MISTRAL_VERSION} --st2chatops=${ST2CHATOPS_VERSION} \
-    --user=${CIRCLE_PROJECT_USERNAME} --repo=${CIRCLE_PROJECT_REPONAME} \
-    --buildurl=${CIRCLE_BUILD_URL} --sha=${CIRCLE_SHA1}
+RUN /install.sh
 
 # Unless these lines are changed, the services are not started when runlevel -> 2
 # Call mistral-db-manage before mistral starts

--- a/images/stackstorm/Dockerfile
+++ b/images/stackstorm/Dockerfile
@@ -77,23 +77,11 @@ ARG ST2MISTRAL_VERSION
 COPY bin/install.sh /install.sh
 
 # It is not possible to dynamically set ARG's, so we do the needful in bin/install.sh
-RUN /install.sh --tag=${ST2_TAG} --st2=${ST2_VERSION} --st2web=${ST2WEB_VERSION} --st2mistral=${ST2MISTRAL_VERSION} --user=${CIRCLE_PROJECT_USERNAME} --repo=${CIRCLE_PROJECT_REPONAME} --buildurl=${CIRCLE_BUILD_URL} --sha=${CIRCLE_SHA1}
-
-# Install chatops and disable unless entrypoint.d file is present
-# Install st2-chatops with Node.js v6/v10 requirement
-# This sorts (descending) a two-element list containing "2.10" and "${ST2_VERSION}",
-# using GNU sort's version comparison (-V).
-# If the "2.10" element is the first element, then $ST2_VERSION >= 2.10.
-# If ST2_VERSION is >= 2.10, then install Node.js v10. Otherwise, install Node.js v6.
-RUN if [ -n "${ST2_VERSION}" ]; then \
-        if [ $(printf "2.10\n${ST2_VERSION}\n" | sort -V | head -n 1) = "2.10" ]; then \
-            (curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override); \
-        else \
-            (curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override); \
-        fi; \
-    else \
-        (curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override); \
-    fi
+# Install st2, st2web, st2mistral and st2chatops
+RUN /install.sh --tag=${ST2_TAG} --st2=${ST2_VERSION} --st2web=${ST2WEB_VERSION} \
+    --st2mistral=${ST2MISTRAL_VERSION} --st2chatops=${ST2CHATOPS_VERSION} \
+    --user=${CIRCLE_PROJECT_USERNAME} --repo=${CIRCLE_PROJECT_REPONAME} \
+    --buildurl=${CIRCLE_BUILD_URL} --sha=${CIRCLE_SHA1}
 
 # Unless these lines are changed, the services are not started when runlevel -> 2
 # Call mistral-db-manage before mistral starts

--- a/images/stackstorm/bin/install.sh
+++ b/images/stackstorm/bin/install.sh
@@ -3,68 +3,42 @@
 set -euo pipefail
 IDS=$'\n\t'
 
-# Parse options
-while [[ "$#" > 1 ]]; do case $1 in
-  --tag) ST2_TAG="$2";;
-  --st2) ST2_VERSION="$2";;
-  --st2web) ST2WEB_VERSION="$2";;
-  --st2mistral) ST2MISTRAL_VERSION="$2";;
-  --st2chatops) ST2CHATOPS_VERSION="$2";;
-  --repo) CIRCLE_PROJECT_REPONAME="$2";;
-  --user) CIRCLE_PROJECT_USERNAME="$2";;
-  --buildurl) CIRCLE_BUILD_URL="$2";;
-  --sha) CIRCLE_SHA1="$2";;
-  *) break;;
-esac; shift; shift;
-done
-
 # apt-cache may not have current package data without apt-get update
 apt-get update
 
-# FIXME: De-duplicate following commands - initial effort to do so failed
-if [ -z ${ST2_VERSION:-} ]; then
-  if [[ -n ${ST2_TAG:-} ]]; then
-    ST2_VERSION="$(apt-cache madison st2 | cut -f 2 -d '|' | tr -d '[ \t]' | grep ${ST2_TAG} | head -1)"
+declare -A vers=()
+declare -A pkgs=( ["ST2_VERSION"]="st2" \
+                  ["ST2WEB_VERSION"]="st2web" \
+                  ["ST2MISTRAL_VERSION"]="st2mistral" \
+                  ["ST2CHATOPS_VERSION"]="st2chatops" )
+
+# Expand keys of pkgs array.
+for i in "${!pkgs[@]}"
+do
+  # Save the newest available version of $pkgs[$i]
+  if [ -z ${!i:-} ]; then
+    vers["$i"]=$(apt-cache madison ${pkgs["$i"]} | cut -f 2 -d '|' | tr -d '[ \t]' | grep "^${ST2_TAG:-}" | head -1)
   else
-    ST2_VERSION="$(apt-cache madison st2 | cut -f 2 -d '|' | tr -d '[ \t]' | head -1)"
+    vers["$i"]=${!i}
   fi
-fi
-if [ -z ${ST2WEB_VERSION:-} ]; then
-  if [[ -n ${ST2_TAG:-} ]]; then
-    ST2WEB_VERSION="$(apt-cache madison st2web | cut -f 2 -d '|' | tr -d '[ \t]' | grep ${ST2_TAG} | head -1)"
-  else
-    ST2WEB_VERSION="$(apt-cache madison st2web | cut -f 2 -d '|' | tr -d '[ \t]' | head -1)"
-  fi
-fi
-if [ -z ${ST2MISTRAL_VERSION:-} ]; then
-  if [[ -n ${ST2_TAG:-} ]]; then
-    ST2MISTRAL_VERSION="$(apt-cache madison st2mistral | cut -f 2 -d '|' | tr -d '[ \t]' | grep ${ST2_TAG} | head -1)"
-  else
-    ST2MISTRAL_VERSION="$(apt-cache madison st2mistral | cut -f 2 -d '|' | tr -d '[ \t]' | head -1)"
-  fi
-fi
-if [ -z ${ST2CHATOPS_VERSION:-} ]; then
-  if [[ -n ${ST2_TAG:-} ]]; then
-    ST2CHATOPS_VERSION="$(apt-cache madison st2chatops | cut -f 2 -d '|' | tr -d '[ \t]' | grep ${ST2_TAG} | head -1)"
-  else
-    ST2CHATOPS_VERSION="$(apt-cache madison st2chatops | cut -f 2 -d '|' | tr -d '[ \t]' | head -1)"
-  fi
-fi
+done
 
 # Install st2, st2web, and st2mistral
-sudo apt-get update
-sudo apt-get install -y st2=${ST2_VERSION} st2web=${ST2WEB_VERSION} st2mistral=${ST2MISTRAL_VERSION}
+sudo apt-get install -y st2=${vers['ST2_VERSION']} st2web=${vers['ST2WEB_VERSION']} st2mistral=${vers['ST2MISTRAL_VERSION']}
 
 # Install st2chatops, but disable unless entrypoint.d file is present
 # Using GNU sort's version comparison, this performs a descending sort on
-# a two element list containing "2.10" and "${ST2_VERSION}".
+# a two element list containing "2.10" and ${vers['ST2CHATOPS_VERSION']}.
 # If the "2.10.0" element is the first element, then install node.js v10.
 # Else, install node.js v6.
-if [ $(printf "2.10.0\n${ST2_VERSION}\n" | sort -V | head -n 1) = "2.10.0" ]; then
-    (curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override);
-else
-    (curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - && sudo apt-get install -y st2chatops && echo manual | sudo tee /etc/init/st2chatops.override);
+node_script="setup_6.x"
+if [ $(printf "2.10.0\n${vers['ST2CHATOPS_VERSION']}\n" | sort -V | head -n 1) = "2.10.0" ]; then
+  node_script="setup_10.x"
 fi
+
+curl -sL https://deb.nodesource.com/${node_script} \
+  | sudo -E bash - && sudo apt-get install -y st2chatops=${vers['ST2CHATOPS_VERSION']} && echo manual \
+  | sudo tee /etc/init/st2chatops.override
 
 MANIFEST="/st2-manifest.txt"
 
@@ -86,7 +60,7 @@ fi
 echo "" >> $MANIFEST
 
 echo "Installed versions:" >> $MANIFEST
-echo "  - st2-${ST2_VERSION}" >> $MANIFEST
-echo "  - st2web-${ST2WEB_VERSION}" >> $MANIFEST
-echo "  - st2mistral-${ST2MISTRAL_VERSION}" >> $MANIFEST
-echo "  - st2chatops-${ST2CHATOPS_VERSION}" >> $MANIFEST
+for i in "${!pkgs[@]}"
+do
+  echo "  - ${pkgs[$i]}-${vers[$i]}" >> $MANIFEST
+done


### PR DESCRIPTION
Prior to this change, `v2.9` was considered greater than `v2.10`.

Also, install st2chatops using `install.sh` because `${ST2_VERSION}` is not necessarily defined outside of this script.