### PR TITLE
1ppc: Add st2scheduler

### DIFF
--- a/images/stackstorm/bin/entrypoint-1ppc.sh
+++ b/images/stackstorm/bin/entrypoint-1ppc.sh
@@ -38,6 +38,10 @@ case "$ST2_SERVICE" in
     DAEMON_ARGS="--config-file /etc/st2/st2.conf"
     exec /opt/stackstorm/st2/bin/st2rulesengine ${DAEMON_ARGS}
     ;;
+  "st2timersengine" )
+    DAEMON_ARGS="--config-file /etc/st2/st2.conf"
+    exec /opt/stackstorm/st2/bin/st2timersengine ${DAEMON_ARGS}
+    ;;
   "st2workflowengine" )
     DAEMON_ARGS="--config-file /etc/st2/st2.conf"
     exec /opt/stackstorm/st2/bin/st2workflowengine ${DAEMON_ARGS}
@@ -45,6 +49,10 @@ case "$ST2_SERVICE" in
   "st2actionrunner" )
     DAEMON_ARGS="--config-file /etc/st2/st2.conf"
     exec /opt/stackstorm/st2/bin/st2actionrunner ${DAEMON_ARGS}
+    ;;
+  "st2scheduler" )
+    DAEMON_ARGS="--config-file /etc/st2/st2.conf"
+    exec /opt/stackstorm/st2/bin/st2scheduler ${DAEMON_ARGS}
     ;;
   "st2resultstracker" )
     DAEMON_ARGS="--config-file /etc/st2/st2.conf"
@@ -57,10 +65,6 @@ case "$ST2_SERVICE" in
   "st2garbagecollector" )
     DAEMON_ARGS="--config-file /etc/st2/st2.conf"
     exec /opt/stackstorm/st2/bin/st2garbagecollector ${DAEMON_ARGS}
-    ;;
-  "st2timersengine" )
-    DAEMON_ARGS="--config-file /etc/st2/st2.conf"
-    exec /opt/stackstorm/st2/bin/st2timersengine ${DAEMON_ARGS}
     ;;
   "mistral-api" )
     set -e

--- a/runtime/compose-1ppc/docker-compose.yml
+++ b/runtime/compose-1ppc/docker-compose.yml
@@ -41,6 +41,14 @@ services:
     <<: *base
     environment:
       - ST2_SERVICE=st2rulesengine
+  st2timersengine:
+    <<: *base
+    environment:
+      - ST2_SERVICE=st2timersengine
+  st2workflowengine:
+    <<: *base
+    environment:
+      - ST2_SERVICE=st2workflowengine
   st2actionrunner:
     <<: *base
     environment:
@@ -49,14 +57,14 @@ services:
     volumes:
       - stackstorm-packs:/opt/stackstorm/packs
       - stackstorm-virtualenvs:/opt/stackstorm/virtualenvs
+  st2scheduler:
+    <<: *base
+    environment:
+      - ST2_SERVICE=st2scheduler
   st2resultstracker:
     <<: *base
     environment:
       - ST2_SERVICE=st2resultstracker
-  st2workflowengine:
-    <<: *base
-    environment:
-      - ST2_SERVICE=st2workflowengine
   st2notifier:
     <<: *base
     environment:
@@ -65,10 +73,6 @@ services:
     <<: *base
     environment:
       - ST2_SERVICE=st2garbagecollector
-  st2timersengine:
-    <<: *base
-    environment:
-      - ST2_SERVICE=st2timersengine
   mistral-api:
     <<: *base
     environment:


### PR DESCRIPTION
Fixes #166 

I also did a minor code cleanup. The order of each components in 1ppc sh or docker-compose.yml is aligned to https://docs.stackstorm.com/reference/ha.html