### PR TITLE
Update docs on how to configure st2chatops

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,10 @@ To enable chatops, delete the file `/etc/init/st2chatops.override` using a scrip
   sudo rm /etc/init/st2chatops.override
   ```
 
-You also need to configure st2chatops, either:
+You also need to configure st2chatops, replace `/opt/stackstorm/chatops/st2chatops.env` with one
+that is properly configured. The easiest way is to use bind-mount.
 
-- by passing all required parameters for st2chatops to the stackstorm container via environment variables OR
-- by replacing `/opt/stackstorm/chatops/st2chatops.env` with one that is properly configured. The easiest way is to use bind-mount.
-
-See [st2chatops.env](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env) for the required variables.
+See [st2chatops.env](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env) for therequired variables.
 
 ## packs.dev directory
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ To enable chatops, delete the file `/etc/init/st2chatops.override` using a scrip
 You also need to configure st2chatops, replace `/opt/stackstorm/chatops/st2chatops.env` with one
 that is properly configured. The easiest way is to use bind-mount.
 
-See [st2chatops.env](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env) for therequired variables.
+See [st2chatops.env](https://github.com/StackStorm/st2chatops/blob/master/st2chatops.env) for the required variables.
 
 ## packs.dev directory
 

--- a/images/stackstorm-all/README.md
+++ b/images/stackstorm-all/README.md
@@ -4,7 +4,7 @@
 
 - This repo contains what's needed to build a Docker image for [stackstorm](https://stackstorm.com/). Has been tested with version  2.1.2.
 - This is an All-in-One type of image because all components and services required for StackStorm are included in the same image. This differs from a the classical microservices model of having one container per service.
-- This is less intended for a producation usage (or for smalle environements only)  but rather more intended for testing / prototyping / CI jobs etc ...
+- This is less intended for a producation usage (or for small environments only)  but rather more intended for testing / prototyping / CI jobs etc ...
 - All various modules are installed and available, with the exception of the ChatOps part (Roadmap).
 - Thanks to Baptiste Assmann who helped.
 
@@ -79,7 +79,7 @@ docker exec -it my_st2 ls -l my_pack
 ```
 
 Please note, that for st2, mounting data to the container at the right even at the right location, is the first step, but that is not enough to use that code. You'll need to go through few steps before being able to use it.
-- Setting up the virtual environements: ```st2 run packs.setup_virtualenv packs=my_pack```
+- Setting up the virtual environments: ```st2 run packs.setup_virtualenv packs=my_pack```
 - Register the pack ```st2ctl restart```
 - Then check if the pack and its actions have been registered: ```st2 pack list``` & ```st2 action list -p my_pack```
 


### PR DESCRIPTION
See #163.

In the `README.md`, remove reference to:

> by passing all required parameters for st2chatops to the stackstorm container via environment variables

The HUBOT env vars are not defined in the scope where `hubot` is executed by `upstart` (on ubuntu14).

```
UPSTART_INSTANCE=
UPSTART_JOB=st2chatops
PATH=/opt/stackstorm/chatops/node_modules/.bin:/opt/stackstorm/chatops/node_modules/hubot/node_modules/.bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
PWD=/opt/stackstorm/chatops
```