### PR TITLE
mod tutorial.md issue-#180

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -6,7 +6,9 @@ We will add a simple action that runs a local shell command.
 Run the following from your docker host.
 
 ```
+sudo chown $USERNAME:$USERNAME packs.dev
 mkdir -p packs.dev/tutorial/actions
+sudo chown -R $USERNAME:$USERNAME packs.dev
 cp tutorial/actions/hello.yaml packs.dev/tutorial/actions
 ```
 


### PR DESCRIPTION
Closes #180, as the following error occurred to me.

mkdir: cannot create directory ‘packs.dev/tutorial’: Permission denied
https://github.com/StackStorm/st2-docker/issues/180