### PR TITLE
README-Update: path to the admin credentials was outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ docker-compose up -d
 docker-compose exec stackstorm bash
 ```
 
-Open `https://localhost` in your browser. StackStorm Username/Password can be found in: `cat conf/stackstorm.env`
+Open `https://localhost` in your browser. StackStorm Username/Password can be found in: `cat ~/.st2/config`
 
 
 ## Usage


### PR DESCRIPTION
This PR updates the TL;DR part of the documentation to catch up with the latest stackstorm container:

Tested with the stackstorm:latest image:
root@1b433980c918:~# st2 --version 
st2 3.1.0, on Python 2.7.6

