### PR TITLE
Deprecate all-in-one Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# StackStorm in Docker containers
+# StackStorm in all-in-one Docker container
+
+> **DEPRECATED!**
+>
+> This all-in-one Docker demo deployment wasn't supported for a long time and is deprecated.
+> Latest StackStorm release that supported all-in-one docker was `v3.1.0` based on outdated `Ubuntu Trusty` with `python 2`.
 
 [![Circle CI Build Status](https://circleci.com/gh/StackStorm/st2-docker/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/st2-docker)
 [![Go to Docker Hub](https://img.shields.io/badge/Docker%20Hub-%E2%86%92-blue.svg)](https://hub.docker.com/r/stackstorm/stackstorm/)


### PR DESCRIPTION
This all-in-one Docker demo deployment wasn't supported for a long time, was missing expected development/maintenance effort with no contributors and is deprecated now.

Latest StackStorm release that supported all-in-one docker was `v3.1.0` based on `Ubuntu Trusty` with `python 2`. As we deprecated Ubuntu Trusty, there are no all-in-one Docker images deploys for later st2 releases.

----
There is a `docker-compose` alternative based on `st2-dockerfiles` images based on `Ubuntu:bionic` and `python 3` with better security and following Docker best practices, see: 
**https://github.com/StackStorm/st2-dockerfiles/pull/28**

It will replace the `st2-docker` contents soon, while current codebase will be archived into a dedicated `DEPRECATED-all-in-one` branch. With that change, both `K8s` and `docker-compose` deployments will eventually use the same https://github.com/StackStorm/st2-dockerfiles/ images.