### PR TITLE
Share with the st2client all the possible resources, files and dirs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,8 +191,14 @@ services:
       ST2_API_URL: ${ST2_API_URL:-http://st2api:9101/}
       ST2_STREAM_URL: ${ST2_STREAM_URL:-http://st2stream:9102/}
     volumes:
-      - ./scripts/st2client-startup.sh:/st2client-startup.sh
+      - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
+      - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
+      - stackstorm-keys:/etc/st2/keys:rw
+      - stackstorm-packs-configs:/opt/stackstorm/configs:rw
+      - stackstorm-packs:/opt/stackstorm/packs:rw
+      - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:rw
       - ./files/st2-cli.conf:/root/.st2/config
+      - ./scripts/st2client-startup.sh:/st2client-startup.sh
   # external services
   mongo:
     image: mongo:4.0


### PR DESCRIPTION
This PR shares with `st2client` container all the resources like keys, pack content, st2.conf and everything else to make the st2 CLI experience in `st2client` container first-class.