### PR TITLE
Switch Docker images to v3.3.0 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Open `http://localhost/` in your browser. StackStorm Username/Password by defaul
 
 The image version, exposed ports, and "packs.dev" directory is configurable with environment variables.
 
-- **ST2_VERSION** this is the tag at the end of the docker image (ie: stackstorm/st2api:v3.3dev)
+- **ST2_VERSION** this is the tag at the end of the docker image (ie: stackstorm/st2api:v3.3.0)
 - **ST2_IMAGE_REPO** The image or path to the images. Default is "stackstorm/".  You may change this is using the Enterprise version or a private docker repository.
 - **ST2_EXPOSE_HTTP**  Port to expose st2web port 80 on.  Default is `127.0.0.1:80`, and you may want to do `0.0.0.0:80` to expose on all interfaces.
 - **ST2_PACKS_DEV** Directory to development packs, absolute or relative to docker-compose.yml. This allows you to develop packs locally. Default is `./packs.dev`. When making a number of packs, it is recommended to make a directory outside of st2-docker, with each subdirectory underneath that being an independent git repo.  Example: `ST2_PACKS_DEV=${HOME}/mypacks`, with `${HOME}/mypacks/st2-helloworld` being a git repo for the "helloworld" pack.
@@ -116,7 +116,7 @@ Example:
 
 ```shell
 $ docker-compose exec st2client bash
-Welcome to StackStorm v3.3dev (Ubuntu 18.04.4 LTS GNU/Linux x86_64)
+Welcome to StackStorm v3.3.0 (Ubuntu 18.04.4 LTS GNU/Linux x86_64)
  * Documentation: https://docs.stackstorm.com/
  * Community: https://stackstorm.com/community-signup
  * Forum: https://forum.stackstorm.com/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   st2web:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2web:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2web:${ST2_VERSION:-3.3.0}
     restart: on-failure
     environment:
       ST2_AUTH_URL: ${ST2_AUTH_URL:-http://st2auth:9100/}
@@ -29,7 +29,7 @@ services:
       - public
     dns_search: .
   st2makesecrets:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-3.3.0}
     restart: on-failure
     networks:
       - private
@@ -39,7 +39,7 @@ services:
     dns_search: .
     command: /makesecrets.sh
   st2api:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2api:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2api:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["mongo", "rabbitmq", "st2makesecrets"]
     networks:
@@ -57,7 +57,7 @@ services:
       - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:rw
     dns_search: .
   st2stream:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2stream:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2stream:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -67,7 +67,7 @@ services:
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
     dns_search: .
   st2scheduler:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2scheduler:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2scheduler:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -77,7 +77,7 @@ services:
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
     dns_search: .
   st2workflowengine:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2workflowengine:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2workflowengine:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -87,7 +87,7 @@ services:
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
     dns_search: .
   st2auth:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2auth:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2auth:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -98,7 +98,7 @@ services:
       - ./files/htpasswd:/etc/st2/htpasswd:ro
     dns_search: .
   st2actionrunner:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -113,7 +113,7 @@ services:
       - stackstorm-ssh:/home/stanley.ssh
     dns_search: .
   st2garbagecollector:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2garbagecollector:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2garbagecollector:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -123,7 +123,7 @@ services:
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
     dns_search: .
   st2notifier:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2notifier:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2notifier:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -133,7 +133,7 @@ services:
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
     dns_search: .
   st2resultstracker:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2resultstracker:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2resultstracker:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -143,7 +143,7 @@ services:
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
     dns_search: .
   st2rulesengine:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2rulesengine:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2rulesengine:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -153,7 +153,7 @@ services:
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
     dns_search: .
   st2sensorcontainer:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2sensorcontainer:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2sensorcontainer:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -167,7 +167,7 @@ services:
       - stackstorm-packs-configs:/opt/stackstorm/configs:ro
       - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:ro
   st2timersengine:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2timersengine:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2timersengine:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on: ["st2api"]
     networks:
@@ -176,7 +176,7 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
   st2client:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-3.3dev}
+    image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on:
       - st2auth


### PR DESCRIPTION
Bumping the st2 version from `3.3dev` to stable `v3.3.0` as default version for the docker deployment.

Another follow-up https://github.com/StackStorm/st2-docker/issues/201 will be needed to automate the version change on every st2 release.