### PR TITLE
Redis coordination backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2020-11-03
+* Update st2 configuration to use redis as coordination backend. (#195)
+
 ## 2020-07-17
 * Replace docker-compose with a new deployment based on [stackstorm/st2-dockerfiles](https://github.com/StackStorm/st2-dockerfiles/) images relying on `Ubuntu Bionic` and `python 3` since st2 `v3.3dev` (#192)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
   st2api:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2api:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: 
+    depends_on:
       - mongo
       - rabbitmq
       - redis
@@ -63,7 +63,7 @@ services:
   st2stream:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2stream:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: 
+    depends_on:
       - st2api
     networks:
       - private
@@ -97,7 +97,7 @@ services:
   st2auth:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2auth:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: 
+    depends_on:
       - st2api
     networks:
       - private

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2workflowengine:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on:
+      - redis
       - st2api
     networks:
       - private

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     depends_on: 
       - mongo
       - rabbitmq
+      - redis
       - st2makesecrets
     networks:
       - private
@@ -74,6 +75,7 @@ services:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2scheduler:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on:
+      - redis
       - st2api
     networks:
       - private
@@ -107,7 +109,8 @@ services:
   st2actionrunner:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: 
+    depends_on:
+      - redis
       - st2api
     networks:
       - private

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,7 @@ services:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2notifier:${ST2_VERSION:-3.3.0}
     restart: on-failure
     depends_on:
+      - redis
       - st2api
     networks:
       - private

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,10 @@ services:
   st2api:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2api:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["mongo", "rabbitmq", "st2makesecrets"]
+    depends_on: 
+      - mongo
+      - rabbitmq
+      - st2makesecrets
     networks:
       - private
     environment:
@@ -59,7 +62,8 @@ services:
   st2stream:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2stream:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on: 
+      - st2api
     networks:
       - private
     volumes:
@@ -69,7 +73,8 @@ services:
   st2scheduler:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2scheduler:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on:
+      - st2api
     networks:
       - private
     volumes:
@@ -79,7 +84,8 @@ services:
   st2workflowengine:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2workflowengine:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on:
+      - st2api
     networks:
       - private
     volumes:
@@ -89,7 +95,8 @@ services:
   st2auth:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2auth:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on: 
+      - st2api
     networks:
       - private
     volumes:
@@ -100,7 +107,8 @@ services:
   st2actionrunner:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on: 
+      - st2api
     networks:
       - private
     volumes:
@@ -115,7 +123,8 @@ services:
   st2garbagecollector:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2garbagecollector:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on:
+      - st2api
     networks:
       - private
     volumes:
@@ -125,7 +134,8 @@ services:
   st2notifier:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2notifier:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on:
+      - st2api
     networks:
       - private
     volumes:
@@ -135,7 +145,8 @@ services:
   st2resultstracker:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2resultstracker:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on:
+      - st2api
     networks:
       - private
     volumes:
@@ -145,7 +156,8 @@ services:
   st2rulesengine:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2rulesengine:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on:
+      - st2api
     networks:
       - private
     volumes:
@@ -155,7 +167,8 @@ services:
   st2sensorcontainer:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2sensorcontainer:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on:
+      - st2api
     networks:
       - private
     dns_search: .
@@ -169,7 +182,8 @@ services:
   st2timersengine:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2timersengine:${ST2_VERSION:-3.3.0}
     restart: on-failure
-    depends_on: ["st2api"]
+    depends_on:
+      - st2api
     networks:
       - private
     dns_search: .

--- a/files/st2.docker.conf
+++ b/files/st2.docker.conf
@@ -7,6 +7,7 @@
 # The order of merging: st2.conf < st2.docker.conf < st2.user.conf
 [auth]
 api_url = http://st2api:9101/
+
 [messaging]
 url = amqp://guest:guest@rabbitmq:5672
 
@@ -26,3 +27,6 @@ connection_timeout = 3000
 
 [content]
 packs_base_paths=/opt/stackstorm/packs.dev
+
+[coordination]
+url = redis://redis:6379


### PR DESCRIPTION
This PR contains a small change to unify the formatting of dependencies in the docker-compose file and uses redis as coordination backend. 

I added redis as dependency to all those components that use the st2common coordination service. 

Closes #195 