### PR TITLE
Remove st2resultstracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2020-11-05
+* Deprecate st2resultstracker which is obsolete since the Mistral deprecation with st2 `v3.3.0`.
+
 ## 2020-07-17
 * Replace docker-compose with a new deployment based on [stackstorm/st2-dockerfiles](https://github.com/StackStorm/st2-dockerfiles/) images relying on `Ubuntu Bionic` and `python 3` since st2 `v3.3dev` (#192)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,16 +132,6 @@ services:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
     dns_search: .
-  st2resultstracker:
-    image: ${ST2_IMAGE_REPO:-stackstorm/}st2resultstracker:${ST2_VERSION:-3.3.0}
-    restart: on-failure
-    depends_on: ["st2api"]
-    networks:
-      - private
-    volumes:
-      - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
-      - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
-    dns_search: .
   st2rulesengine:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2rulesengine:${ST2_VERSION:-3.3.0}
     restart: on-failure


### PR DESCRIPTION
This PR removes st2resultstracker from the docker-compose file. This PR is to be merged before https://github.com/StackStorm/st2-dockerfiles/pull/40