### PR TITLE
Make sure action runner service has access to the datastore keys 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,10 @@ jobs:
             # TODO: Replace with 'docker-compose run status'
             # Example: https://github.com/docker/compose/issues/374#issuecomment-310266246
             sleep 45
+
+            # Display logs to help troubleshoot build failures, etc
+            docker-compose logs --tail="500" st2api
+
             # TODO: Replace with more organized BATS tests 'docker-compose run tests'
             # Example: https://github.com/StackStorm/stackstorm-ha/blob/master/tests/st2tests.sh
             docker-compose exec st2client st2 action list --pack=core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,6 @@ jobs:
             # Example: https://github.com/docker/compose/issues/374#issuecomment-310266246
             sleep 45
 
-            # Display logs to help troubleshoot build failures, etc
-            docker-compose logs --tail="500" st2api
-
             # TODO: Replace with more organized BATS tests 'docker-compose run tests'
             # Example: https://github.com/StackStorm/stackstorm-ha/blob/master/tests/st2tests.sh
             docker-compose exec st2client st2 action list --pack=core
@@ -41,9 +38,13 @@ jobs:
             docker-compose exec st2client st2 pack install github
             docker-compose exec st2client st2 execution list
       - run:
-          when: always
-          name: List created Services
-          command: docker-compose ps
+          when: on_fail
+          name: Troubleshooting the build failure
+          command: |
+            docker-compose ps
+            # Display logs to help troubleshoot build failures, etc
+            docker-compose logs --tail="500" st2api
+
 
 workflows:
   version: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
-      - stackstorm-keys:/etc/st2/keys:rw
+      - stackstorm-keys:/etc/st2/keys:ro
       - stackstorm-packs-configs:/opt/stackstorm/configs:rw
       - stackstorm-packs:/opt/stackstorm/packs:rw
       - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:rw
@@ -125,7 +125,7 @@ services:
       - stackstorm-ssh:/home/stanley.ssh
       # Action runner needs access to keys since action definitions (Jinja
       # templates) can reference secrets
-      - stackstorm-keys:/etc/st2/keys:rw
+      - stackstorm-keys:/etc/st2/keys:ro
     dns_search: .
   st2garbagecollector:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2garbagecollector:${ST2_VERSION:-3.3.0}
@@ -204,7 +204,11 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
-      - stackstorm-keys:/etc/st2/keys:rw
+      # Technically, client container doesn't need or should have access to the
+      # keys in prod setup, but here we make it available to end user for
+      # testing and transparency reasons since this setup is primarily mean to
+      # be used for testing and development.
+      - stackstorm-keys:/etc/st2/keys:ro
       - stackstorm-packs-configs:/opt/stackstorm/configs:rw
       - stackstorm-packs:/opt/stackstorm/packs:rw
       - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,9 @@ services:
       - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:rw
       - stackstorm-virtualenvs:/opt/stackstorm/virtualenvs:rw
       - stackstorm-ssh:/home/stanley.ssh
+      # Action runner needs access to keys since action definitions (Jinja
+      # templates) can reference secrets
+      - stackstorm-keys:/etc/st2/keys:rw
     dns_search: .
   st2garbagecollector:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2garbagecollector:${ST2_VERSION:-3.3.0}


### PR DESCRIPTION
This pull request updates docker compose definition for action runner service to make sure it has service to crypto key which is used to encrypt / decrypt datastore values.

Without it, you will see an error like this if you try to run an alias or action which references a secret and uses ``decrypt_kv`` filter.

```bash
result: 
  error: 'Failed to run task "foo". Parameter rendering failed.. Failed rendering value for action parameter "token" in task "foo" (template string=foo|decrypt_kv }}{% endif %}): [Errno 2] No such file or directory: ''/etc/st2/keys/datastore_key.json'''
  published: {}
  tasks: []
  traceback: "Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/action_chain_runner/action_chain_runner.py", line 706, in _resolve_params
    context=context)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/jinja.py", line 159, in render_values
    raise e
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/jinja.py", line 154, in render_values
    rendered_v = env.from_string(v).render(super_context)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 1, in top-level template code
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/expressions/functions/datastore.py", line 51, in decrypt_kv
    crypto_key = read_crypto_key(key_path=crypto_key_path)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/util/crypto.py", line 167, in read_crypto_key
    with open(key_path, 'r') as fp:
FileNotFoundError: [Errno 2] No such file or directory: '/etc/st2/keys/datastore_key.json'
```

At this point it would also be good to audit and confirm if any of those other services such as workflow engine and notifier also need access to that key.

Related issue #211.