### PR TITLE
add stackstorm-keys volume to workflowengine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
+      - stackstorm-keys:/etc/st2/keys:ro
     dns_search: .
   st2auth:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2auth:${ST2_VERSION:-3.3.0}


### PR DESCRIPTION
Workflowengine doesn't mount the stackstorm-keys volume to allow actions to decrypt datastore items. Ran this update though circleci and it passed. Fixes #214 