### PR TITLE
Remove unused "stackstorm-postgres" named volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,7 +245,6 @@ volumes:
     stackstorm-mongodb:
     stackstorm-rabbitmq:
     stackstorm-redis:
-    stackstorm-postgres:
     stackstorm-packs:
     stackstorm-packs-configs:
     stackstorm-keys:


### PR DESCRIPTION
This pull request removes unused named ``stackstorm-postgres`` docker volume.

I assume we forgot to remove it when removing support for Mistral.