### PR TITLE
Upgrade Redis image to v6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Changelog
+# Changelo
+
+## 2021-04-10
+* Upgrade used Redis Docker image to 6.2.
 
 ## 2021-04-06
 * Add information on how to utilize a custom config with st2web container. (#225)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,7 +265,7 @@ services:
     volumes:
       - stackstorm-rabbitmq:/var/lib/rabbitmq
   redis:
-    image: redis:6.0
+    image: redis:6.2
     restart: on-failure
     networks:
       - private


### PR DESCRIPTION
Small update to the Redis Docker image we use - https://github.com/redis/redis/releases.

I also noticed we don't use alpine version of the image which is probably fine since it's only 20 MB or so difference in size.