### PR TITLE
remove "dns_search: ." based on discussion in #231

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2021-12-02
+* Removed `dns_search: .` from all services in `docker-compose.yml` per discussion in #231
+
 ## 2021-04-15
 * Add BATS testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     networks:
       - private
       - public
-    dns_search: .
   st2makesecrets:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-latest}
     restart: on-failure
@@ -39,7 +38,6 @@ services:
     volumes:
       - ./scripts/makesecrets.sh:/makesecrets.sh
       - stackstorm-keys:/etc/st2/keys:rw
-    dns_search: .
     command: /makesecrets.sh
   st2api:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2api:${ST2_VERSION:-latest}
@@ -63,7 +61,6 @@ services:
       - stackstorm-packs:/opt/stackstorm/packs:rw
       - ./files/rbac:/opt/stackstorm/rbac:rw
       - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:rw
-    dns_search: .
   st2stream:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2stream:${ST2_VERSION:-latest}
     restart: on-failure
@@ -74,7 +71,6 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
-    dns_search: .
   st2scheduler:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2scheduler:${ST2_VERSION:-latest}
     restart: on-failure
@@ -86,7 +82,6 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
-    dns_search: .
   st2workflowengine:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2workflowengine:${ST2_VERSION:-latest}
     restart: on-failure
@@ -99,7 +94,6 @@ services:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
       - stackstorm-keys:/etc/st2/keys:ro
-    dns_search: .
   st2auth:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2auth:${ST2_VERSION:-latest}
     restart: on-failure
@@ -111,7 +105,6 @@ services:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
       - ./files/htpasswd:/etc/st2/htpasswd:ro
-    dns_search: .
   st2actionrunner:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2actionrunner:${ST2_VERSION:-latest}
     restart: on-failure
@@ -131,7 +124,6 @@ services:
       # Action runner needs access to keys since action definitions (Jinja
       # templates) can reference secrets
       - stackstorm-keys:/etc/st2/keys:ro
-    dns_search: .
   st2garbagecollector:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2garbagecollector:${ST2_VERSION:-latest}
     restart: on-failure
@@ -142,7 +134,6 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
-    dns_search: .
   st2notifier:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2notifier:${ST2_VERSION:-latest}
     restart: on-failure
@@ -154,7 +145,6 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
-    dns_search: .
   st2rulesengine:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2rulesengine:${ST2_VERSION:-latest}
     restart: on-failure
@@ -165,7 +155,6 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
-    dns_search: .
   st2sensorcontainer:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2sensorcontainer:${ST2_VERSION:-latest}
     restart: on-failure
@@ -173,7 +162,6 @@ services:
       - st2api
     networks:
       - private
-    dns_search: .
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
@@ -188,7 +176,6 @@ services:
       - st2api
     networks:
       - private
-    dns_search: .
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
   st2client:
@@ -248,7 +235,6 @@ services:
       HUBOT_SLACK_TOKEN: ${HUBOT_SLACK_TOKEN:-}
     volumes:
       - ./scripts/st2chatops-startup.sh:/st2chatops-startup.sh
-    dns_search: .
   # external services
   mongo:
     image: mongo:4.0
@@ -257,13 +243,11 @@ services:
       - private
     volumes:
       - stackstorm-mongodb:/data/db
-    dns_search: .
   rabbitmq:
     image: rabbitmq:3.8
     restart: on-failure
     networks:
       - private
-    dns_search: .
     volumes:
       - stackstorm-rabbitmq:/var/lib/rabbitmq
   redis:
@@ -271,7 +255,6 @@ services:
     restart: on-failure
     networks:
       - private
-    dns_search: .
     volumes:
       - stackstorm-redis:/data
 


### PR DESCRIPTION
Based on the discussion in #231 and details provided by @ytjohn it sounds like `dns_search: .` is more or less outdated in the `docker-compose.yml` with "modern" container runtimes.  Also seems like it _might_ be indirectly breaking DNS on some container platforms so let's just remove it. 🙂 

Closes #231 