### PR TITLE
fix typo in stanley ssh key volume mount location

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - stackstorm-packs:/opt/stackstorm/packs:rw
       - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:rw
       - stackstorm-virtualenvs:/opt/stackstorm/virtualenvs:rw
-      - stackstorm-ssh:/home/stanley.ssh
+      - stackstorm-ssh:/home/stanley/.ssh
       # Action runner needs access to keys since action definitions (Jinja
       # templates) can reference secrets
       - stackstorm-keys:/etc/st2/keys:ro


### PR DESCRIPTION
Just /home/stanley.ssh -> /home/stanley/.ssh for ssh key volume mount