### PR TITLE
Fix incorrect docker-compose.yml configuration (fixes #248)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,7 @@ services:
       # for the full list of supported adapters and example ENV variables.
       HUBOT_ADAPTER: ${HUBOT_ADAPTER:-slack}
       HUBOT_LOG_LEVEL: ${HUBOT_LOG_LEVEL:-debug}
-      HUBOT_SLACK_TOKEN: ${HUBOT_SLACK_TOKEN:-}
+      HUBOT_SLACK_TOKEN: ${HUBOT_SLACK_TOKEN:-token}
     volumes:
       - ./scripts/st2chatops-startup.sh:/st2chatops-startup.sh
   # external services


### PR DESCRIPTION
* The current docker-compose.yml file has a misconfigured
  environment variable in the st2chatops service
  - HUBOT_SLACK_TOKEN

* This misconfiguration causes docker-compose to fail
  while parsing the file

* A simple fix to add a temporary value "token" to allow
  the services to come up

* Users should configure this environment variable in the
  .env file to use the service securely