### PR TITLE
Honor docker-compose exit codes

### DIFF
--- a/.github/workflows/st2-docker.yml
+++ b/.github/workflows/st2-docker.yml
@@ -54,7 +54,6 @@ jobs:
       #     fi
 
       - name: Run st2 smoke-tests
-        working-directory: tests
         run: |
           docker-compose --file tests/st2tests.yaml run st2test-tools
 

--- a/.github/workflows/st2-docker.yml
+++ b/.github/workflows/st2-docker.yml
@@ -37,20 +37,25 @@ jobs:
         run: |
           sleep 60
 
+      # - name: Run st2 smoke-tests
+      #   run: |
+      #     docker-compose --file tests/st2tests.yaml up --no-color 2>&1 \
+      #       | tee /tmp/compose.log
+
+      #     rc="$(grep -q 'tests_st2test-tools_1 exited with code 0' /tmp/compose.log 2>/dev/null; echo $?)"
+      #     if [[ $rc -ne 0 ]]; then
+      #       exit 1
+      #     fi
+
+      #     rc="$(grep -q 'tests_st2test_1 exited with code 0' /tmp/compose.log 2>/dev/null; echo $?)"
+      #     if [[ $rc -ne 0 ]]; then
+      #       exit 1
+      #     fi
+
       - name: Run st2 smoke-tests
+        working-directory: tests
         run: |
-          docker-compose --file tests/st2tests.yaml up --no-color 2>&1 \
-            | tee /tmp/compose.log
-
-          rc="$(grep -q 'tests_st2test-tools_1 exited with code 0' /tmp/compose.log 2>/dev/null; echo $?)"
-          if [[ $rc -ne 0 ]]; then
-            exit 1
-          fi
-
-          rc="$(grep -q 'tests_st2test_1 exited with code 0' /tmp/compose.log 2>/dev/null; echo $?)"
-          if [[ $rc -ne 0 ]]; then
-            exit 1
-          fi
+          docker-compose --file tests/st2tests.yaml run st2test-tools
 
       - name: Troubleshooting the build failure
         if: ${{ failure() }}

--- a/.github/workflows/st2-docker.yml
+++ b/.github/workflows/st2-docker.yml
@@ -21,6 +21,7 @@ jobs:
 
   docker-compose-up:
     runs-on: ubuntu-latest
+    needs: [docker-compose-lint]
     steps:
       - uses: actions/checkout@v3
 
@@ -32,10 +33,24 @@ jobs:
         run: |
           docker-compose up --detach
 
-      - name: Run st2 smoke-tests
+      - name: Sleep
         run: |
           sleep 60
-          docker-compose -f tests/st2tests.yaml up
+
+      - name: Run st2 smoke-tests
+        run: |
+          docker-compose --file tests/st2tests.yaml up --no-color 2>&1 \
+            | tee /tmp/compose.log
+
+          rc="$(grep -q 'tests_st2test-tools_1 exited with code 0' /tmp/compose.log 2>/dev/null; echo $?)"
+          if [[ $rc -ne 0 ]]; then
+            exit 1
+          fi
+
+          rc="$(grep -q 'tests_st2test_1 exited with code 0' /tmp/compose.log 2>/dev/null; echo $?)"
+          if [[ $rc -ne 0 ]]; then
+            exit 1
+          fi
 
       - name: Troubleshooting the build failure
         if: ${{ failure() }}
@@ -43,3 +58,4 @@ jobs:
           docker-compose ps
           # Display logs to help troubleshoot build failures, etc
           docker-compose logs --tail="500" st2api
+          exit 1

--- a/.github/workflows/st2-docker.yml
+++ b/.github/workflows/st2-docker.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
       - master
-      - issue-251
   schedule:
     - cron: 0 1 * * *
   workflow_dispatch:
@@ -37,21 +36,6 @@ jobs:
       - name: Sleep
         run: |
           sleep 60
-
-      # - name: Run st2 smoke-tests
-      #   run: |
-      #     docker-compose --file tests/st2tests.yaml up --no-color 2>&1 \
-      #       | tee /tmp/compose.log
-
-      #     rc="$(grep -q 'tests_st2test-tools_1 exited with code 0' /tmp/compose.log 2>/dev/null; echo $?)"
-      #     if [[ $rc -ne 0 ]]; then
-      #       exit 1
-      #     fi
-
-      #     rc="$(grep -q 'tests_st2test_1 exited with code 0' /tmp/compose.log 2>/dev/null; echo $?)"
-      #     if [[ $rc -ne 0 ]]; then
-      #       exit 1
-      #     fi
 
       - name: Run st2 smoke-tests
         run: |

--- a/.github/workflows/st2-docker.yml
+++ b/.github/workflows/st2-docker.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run st2 smoke-tests
         run: |
-          docker-compose --file tests/st2tests.yaml run st2test-tools
+          docker-compose --file tests/st2tests.yaml run st2test
 
       - name: Troubleshooting the build failure
         if: ${{ failure() }}

--- a/.github/workflows/st2-docker.yml
+++ b/.github/workflows/st2-docker.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - issue-251
   schedule:
     - cron: 0 1 * * *
   workflow_dispatch:

--- a/tests/st2tests.sh
+++ b/tests/st2tests.sh
@@ -9,7 +9,7 @@ load "${BATS_HELPERS_DIR}/bats-file/load.bash"
   assert_success
   # st2 3.3dev (9ea417346), on Python 3.6.9
   assert_line --partial "st2 ${ST2_VERSION}"
-  assert_line --partial 'on Python 3.6.9'
+  assert_line --partial 'on Python 3.8.10'
 }
 
 @test 'ST2_AUTH_URL service endpoint is accessible and working' {

--- a/tests/st2tests.sh
+++ b/tests/st2tests.sh
@@ -7,7 +7,7 @@ load "${BATS_HELPERS_DIR}/bats-file/load.bash"
 @test 'st2 version deployed and python env are as expected' {
   run st2 --version
   assert_success
-  # st2 3.3dev (9ea417346), on Python 3.6.9
+  # st2 3.7.0, on Python 3.8.10
   assert_line --partial "st2 ${ST2_VERSION}"
   assert_line --partial 'on Python 3.8.10'
 }


### PR DESCRIPTION
Fixes #251; switch to `docker-compose run` for testing (bubbling up error codes is easier than with `docker-compose up`).