### PR TITLE
Bump to new mongo, rabbitmq and redis version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2023-11-04
+* Upgrade to MongoDB v7.0
+* Upgrade to RabbitMQ v3.12
+* Upgrade to Redis v7.2
+
 ## 2023-10-28
 * Refactor st2test, install BATS via `apt install`
 * Remove unneeded file st2test-tools.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Changelog
 
-## 2023-11-04
-* Upgrade to MongoDB v7.0
+## 2023-11-07
 * Upgrade to RabbitMQ v3.12
 * Upgrade to Redis v7.2
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,7 +237,7 @@ services:
       - ./scripts/st2chatops-startup.sh:/st2chatops-startup.sh
   # external services
   mongo:
-    image: mongo:7.0
+    image: mongo:4.4
     restart: on-failure
     networks:
       - private

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -237,21 +237,21 @@ services:
       - ./scripts/st2chatops-startup.sh:/st2chatops-startup.sh
   # external services
   mongo:
-    image: mongo:4.4
+    image: mongo:7.0
     restart: on-failure
     networks:
       - private
     volumes:
       - stackstorm-mongodb:/data/db
   rabbitmq:
-    image: rabbitmq:3.8
+    image: rabbitmq:3.12
     restart: on-failure
     networks:
       - private
     volumes:
       - stackstorm-rabbitmq:/var/lib/rabbitmq
   redis:
-    image: redis:6.2
+    image: redis:7.2
     restart: on-failure
     networks:
       - private


### PR DESCRIPTION
I have updated the external services:
- MongoDB from v4.4 to v7.0
- RabbitMQ from v3.8 to v3.12
- Redis from v6.2 to v7.2

I have performed the following manual tests:
- Installation of a pack
- Execution of a local action
- Execution of a remote action
