### PR TITLE
Grant Rules Engine access to encryption keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,7 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
+      - stackstorm-keys:/etc/st2/keys:ro
   st2sensorcontainer:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2sensorcontainer:${ST2_VERSION:-latest}
     restart: on-failure


### PR DESCRIPTION
st2 rules engine needs access to encryption keys for decrypting values from the datastore. 

This resolves this error that is thrown when attempting to decrypt datastore values inside rules:

`Failed to render parameter "password": [Errno 2] No such file or directory: '/etc/st2/keys/datastore_key.json'`