### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,10 @@ services:
     volumes:
       - ./files/st2.docker.conf:/etc/st2/st2.docker.conf:ro
       - ./files/st2.user.conf:/etc/st2/st2.user.conf:ro
+      # Rule engine runner needs access to keys since workflow action definitions (Jinja
+      # templates) can reference secrets. Using core.st2.IntervalTimer caused Error:
+      # "Failed to render parameter \"passwords\": [Errno 2] No such file or directory: '/etc/st2/keys/datastore_key.json'"
+      - stackstorm-keys:/etc/st2/keys:ro
   st2sensorcontainer:
     image: ${ST2_IMAGE_REPO:-stackstorm/}st2sensorcontainer:${ST2_VERSION:-latest}
     restart: on-failure


### PR DESCRIPTION
Rule engine runner needs access to keys since workflow action definitions (Jinja templates) can reference secrets. 

Using **core.st2.IntervalTimer** caused Error:
"Failed to render parameter \"passwords\": [Errno 2] No such file or directory: '/etc/st2/keys/datastore_key.json'"


**FIX  for [#discussion-6723256](https://github.com/StackStorm/st2/discussions/6205#discussion-6723256)**

**Fixed:**

![image](https://github.com/StackStorm/st2-docker/assets/37928721/b75eefa8-d9b3-4eda-9ce8-acbab47a7fbd)


**Before Fix:**

![image](https://github.com/StackStorm/st2-docker/assets/37928721/698c0313-f115-4420-98db-80afbd503eaa)
