### PR TITLE
Adapt workflows to Docker compose v2 to prevent them from failing

### DIFF
--- a/.github/workflows/st2-docker.yml
+++ b/.github/workflows/st2-docker.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Docker-compose lint check
-        run: docker-compose config
+        run: docker compose config
 
   docker-compose-up:
     runs-on: ubuntu-latest
@@ -27,11 +27,11 @@ jobs:
 
       - name: Pull Docker Images
         run: |
-          docker-compose pull
+          docker compose pull
 
-      - name: Start st2 with docker-compose
+      - name: Start st2 with docker compose
         run: |
-          docker-compose up --detach
+          docker compose up --detach
 
       - name: Sleep
         run: |
@@ -39,12 +39,12 @@ jobs:
 
       - name: Run st2 smoke-tests
         run: |
-          docker-compose --file tests/st2tests.yaml run st2test
+          docker compose --file tests/st2tests.yaml run st2test
 
       - name: Troubleshooting the build failure
         if: ${{ failure() }}
         run: |
-          docker-compose ps
+          docker compose ps
           # Display logs to help troubleshoot build failures, etc
-          docker-compose logs --tail="500" st2api
+          docker compose logs --tail="500" st2api
           exit 1


### PR DESCRIPTION
Docker Compose v1 is deprecated and has been removed from all ubuntu runner images (https://github.com/actions/runner-images/issues/9692). This has caused all workflows since around august to fail with `docker-compose: command not found`.

To adapt to Compose v2 we need to use `docker compose` instead of `docker-compose`, ref the Compose migration guide: https://docs.docker.com/compose/releases/migrate

